### PR TITLE
Feat: FeignClient 설정 추가 및 내부 통신 로직 구현

### DIFF
--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/client/UserClient.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/client/UserClient.java
@@ -1,0 +1,9 @@
+package com.fhsh.daitda.deliverymanager.application.client;
+
+import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+
+import java.util.UUID;
+
+public interface UserClient {
+    UserInfoCommand getUser(UUID userId);
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/command/CreateDeliveryManagerCommand.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/command/CreateDeliveryManagerCommand.java
@@ -1,0 +1,10 @@
+package com.fhsh.daitda.deliverymanager.application.command;
+
+import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+
+import java.util.UUID;
+
+public record CreateDeliveryManagerCommand(
+        UUID targetUserId,
+        DeliveryManagerType type
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/command/UserInfoCommand.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/command/UserInfoCommand.java
@@ -1,0 +1,9 @@
+package com.fhsh.daitda.deliverymanager.application.command;
+
+import java.util.UUID;
+
+public record UserInfoCommand(
+        UUID userId,
+        UUID hubId,
+        String slackUserId
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -5,7 +5,9 @@ import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManager
 import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
 import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerRepository;
+import com.fhsh.daitda.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +28,7 @@ public class DeliveryManagerCommandService {
         validateUser(userInfo, command);
 
         if (deliveryManagerRepository.existsByUserId(userInfo.userId())) {
-            throw new IllegalArgumentException("이미 등록된 배송담당자입니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_ALREADY_EXISTS);
         }
 
         // 배송담당자 순번 지정
@@ -35,7 +37,7 @@ public class DeliveryManagerCommandService {
         int nextSequence = (lastSequence == null) ? 1 : lastSequence + 1;
 
         if (nextSequence > 10) {
-            throw new IllegalArgumentException("배송담당자는 최대 10명까지만 등록할 수 있습니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_LIMIT_EXCEEDED);
         }
 
         // 배송담당자 생성
@@ -52,15 +54,15 @@ public class DeliveryManagerCommandService {
 
     private void validateUser(UserInfoCommand userInfo, CreateDeliveryManagerCommand command) {
         if (userInfo == null) {
-            throw new IllegalArgumentException("대상 사용자를 찾을 수 없습니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.USER_NOT_FOUND);
         }
 
         if (command.type() == DeliveryManagerType.COMPANY && userInfo.hubId() == null) {
-            throw new IllegalArgumentException("업체 배송 담당자는 허브 정보가 필요합니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_HUB_REQUIRED);
         }
 
         if (userInfo.slackUserId() == null || userInfo.slackUserId().isBlank()) {
-            throw new IllegalArgumentException("슬랙 ID가 없는 사용자입니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_SLACK_ID_REQUIRED);
         }
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -1,0 +1,66 @@
+package com.fhsh.daitda.deliverymanager.application.service.command;
+
+import com.fhsh.daitda.deliverymanager.application.client.UserClient;
+import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
+import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
+import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerQueryRepository;
+import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeliveryManagerCommandService {
+
+    private final DeliveryManagerRepository deliveryManagerRepository;
+    private final DeliveryManagerQueryRepository deliveryManagerQueryRepository;
+    private final UserClient userClient;
+
+    public void createDeliveryManager(CreateDeliveryManagerCommand command) {
+        // user-service에서 사용자 정보 받아오기
+        UserInfoCommand userInfo = userClient.getUser(command.targetUserId());
+
+        // 사용자 정보 검증
+        validateUser(userInfo, command);
+
+        if (deliveryManagerQueryRepository.existsByUserId(userInfo.userId())) {
+            throw new IllegalArgumentException("이미 등록된 배송담당자입니다.");
+        }
+
+        // 배송담당자 순번 지정
+        Integer lastSequence = deliveryManagerQueryRepository.findLastSequence(
+                command.type(), userInfo.hubId());
+        int nextSequence = (lastSequence == null) ? 1 : lastSequence + 1;
+
+        // 배송담당자 생성
+        DeliveryManager deliveryManager = DeliveryManager.create(
+                userInfo.userId(),
+                userInfo.hubId(),
+                userInfo.slackUserId(),
+                command.type(),
+                nextSequence
+        );
+
+        deliveryManagerRepository.save(deliveryManager);
+    }
+
+    private void validateUser(UserInfoCommand userInfo, CreateDeliveryManagerCommand command) {
+        if (userInfo == null) {
+            throw new IllegalArgumentException("대상 사용자를 찾을 수 없습니다.");
+        }
+
+        if (command.type() == DeliveryManagerType.COMPANY && userInfo.hubId() == null) {
+            throw new IllegalArgumentException("업체 배송 담당자는 허브 정보가 필요합니다.");
+        }
+
+        if (userInfo.slackUserId() == null || userInfo.slackUserId().isBlank()) {
+            throw new IllegalArgumentException("슬랙 ID가 없는 사용자입니다.");
+        }
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -58,11 +58,11 @@ public class DeliveryManagerCommandService {
         }
 
         if (command.type() == DeliveryManagerType.COMPANY && userInfo.hubId() == null) {
-            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_HUB_REQUIRED);
+            throw new BusinessException(DeliveryManagerErrorCode.COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED);
         }
 
         if (userInfo.slackUserId() == null || userInfo.slackUserId().isBlank()) {
-            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_SLACK_ID_REQUIRED);
+            throw new BusinessException(DeliveryManagerErrorCode.SLACK_ID_REQUIRED);
         }
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -5,13 +5,10 @@ import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManager
 import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
-import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerQueryRepository;
 import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -19,7 +16,6 @@ import java.util.UUID;
 public class DeliveryManagerCommandService {
 
     private final DeliveryManagerRepository deliveryManagerRepository;
-    private final DeliveryManagerQueryRepository deliveryManagerQueryRepository;
     private final UserClient userClient;
 
     public void createDeliveryManager(CreateDeliveryManagerCommand command) {
@@ -29,12 +25,12 @@ public class DeliveryManagerCommandService {
         // 사용자 정보 검증
         validateUser(userInfo, command);
 
-        if (deliveryManagerQueryRepository.existsByUserId(userInfo.userId())) {
+        if (deliveryManagerRepository.existsByUserId(userInfo.userId())) {
             throw new IllegalArgumentException("이미 등록된 배송담당자입니다.");
         }
 
         // 배송담당자 순번 지정
-        Integer lastSequence = deliveryManagerQueryRepository.findLastSequence(
+        Integer lastSequence = deliveryManagerRepository.findLastSequence(
                 command.type(), userInfo.hubId());
         int nextSequence = (lastSequence == null) ? 1 : lastSequence + 1;
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -34,6 +34,10 @@ public class DeliveryManagerCommandService {
                 command.type(), userInfo.hubId());
         int nextSequence = (lastSequence == null) ? 1 : lastSequence + 1;
 
+        if (nextSequence > 10) {
+            throw new IllegalArgumentException("배송담당자는 최대 10명까지만 등록할 수 있습니다.");
+        }
+
         // 배송담당자 생성
         DeliveryManager deliveryManager = DeliveryManager.create(
                 userInfo.userId(),

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/AssignmentCursor.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/AssignmentCursor.java
@@ -1,6 +1,8 @@
 package com.fhsh.daitda.deliverymanager.domain.entity;
 
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
+import com.fhsh.daitda.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -66,18 +68,18 @@ public class AssignmentCursor {
 
     public void advanceTo(int assignedSequence) {
         if (assignedSequence < MIN_SEQUENCE || assignedSequence > MAX_SEQUENCE) {
-            throw new IllegalArgumentException("유효하지 않은 담당자 순번입니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_SEQUENCE_INVALID);
         }
         this.lastAssignedSequence = assignedSequence;
     }
 
     private static void validate(DeliveryManagerType type, UUID hubId) {
         if (type == null) {
-            throw new IllegalArgumentException("담당자 타입은 필수입니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_TYPE_REQUIRED);
         }
 
         if (type == DeliveryManagerType.COMPANY && hubId == null) {
-            throw new IllegalArgumentException("업체 배송 담당자 커서는 허브 ID가 필요합니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED);
         }
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
@@ -25,7 +25,13 @@ import java.util.UUID;
 
 @Entity
 @Getter
-@Table(name = "p_delivery_managers")
+@Table(name = "p_delivery_managers",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_delivery_manager_user_id",
+                        columnNames = "user_id"
+                )
+        })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DeliveryManager extends BaseUserEntity {
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
@@ -1,7 +1,9 @@
 package com.fhsh.daitda.deliverymanager.domain.entity;
 
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
 import com.fhsh.daitda.domain.BaseUserEntity;
+import com.fhsh.daitda.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -113,10 +115,10 @@ public class DeliveryManager extends BaseUserEntity {
     // 배송 시작으로 변경
     public void startDelivery() {
         if (this.isDeleted()) {
-            throw new IllegalStateException("삭제된 배송 담당자는 배송을 시작할 수 없습니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELETED_DELIVERY_MANAGER_CANNOT_CHANGE_STATUS);
         }
         if (this.isDelivery) {
-            throw new IllegalStateException("이미 배송 중인 담당자입니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_ALREADY_DELIVERING);
         }
         this.isDelivery = true;
     }
@@ -124,10 +126,10 @@ public class DeliveryManager extends BaseUserEntity {
     // 배송 완료로 변경
     public void completeDelivery() {
         if (this.isDeleted()) {
-            throw new IllegalStateException("삭제된 배송 담당자는 배송 상태를 변경할 수 없습니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELETED_DELIVERY_MANAGER_CANNOT_CHANGE_STATUS);
         }
         if (!this.isDelivery) {
-            throw new IllegalStateException("배송 중인 상태가 아닙니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_DELIVERING);
         }
         this.isDelivery = false;
     }
@@ -145,10 +147,10 @@ public class DeliveryManager extends BaseUserEntity {
     // 입력 값 검증
     private void validate(DeliveryManagerType type, UUID hubId, int sequence) {
         if (type == null) {
-            throw new IllegalArgumentException("배송 담당자 타입은 필수입니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_TYPE_REQUIRED);
         }
         if (type == DeliveryManagerType.COMPANY && hubId == null) {
-            throw new IllegalArgumentException("업체 배송 담당자는 허브 ID가 필수입니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED);
         }
 
         validateSequence(sequence);
@@ -156,7 +158,7 @@ public class DeliveryManager extends BaseUserEntity {
 
     private static void validateSequence(int sequence) {
         if (sequence < MIN_SEQUENCE || sequence > MAX_SEQUENCE) {
-            throw new IllegalArgumentException("sequence는 1~10 범위여야 합니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_SEQUENCE_INVALID);
         }
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
@@ -55,13 +55,13 @@ public class DeliveryManager extends BaseUserEntity {
     private Long version;
 
     @Builder
-    public DeliveryManager(UUID userId, UUID hubId, String slackId, DeliveryManagerType type, int sequence) {
+    public DeliveryManager(UUID userId, UUID hubId, String slackId, DeliveryManagerType type, int sequence, boolean isDelivery) {
         validate(type, hubId, sequence);
 
         this.managerInfo = ManagerInfo.of(userId, hubId, slackId);
         this.type = type;
         this.sequence = sequence;
-        this.isDelivery = false;
+        this.isDelivery = isDelivery;
     }
 
     // 배송담당자 생성
@@ -73,6 +73,7 @@ public class DeliveryManager extends BaseUserEntity {
                 .slackId(slackId)
                 .type(type)
                 .sequence(sequence)
+                .isDelivery(false)
                 .build();
     }
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/ManagerInfo.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/ManagerInfo.java
@@ -14,12 +14,13 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ManagerInfo {
 
-    @Column(nullable = false)
+    @Column(name = "user_id", nullable = false)
     private UUID userId;
 
+    @Column(name = "hub_id")
     private UUID hubId;
 
-    @Column(length = 100, nullable = false)
+    @Column(name = "slack_id", length = 100, nullable = false)
     private String slackId;
 
     protected ManagerInfo(UUID userId, UUID hubId, String slackId) {

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/ManagerInfo.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/ManagerInfo.java
@@ -1,9 +1,10 @@
 package com.fhsh.daitda.deliverymanager.domain.entity;
 
+import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
+import com.fhsh.daitda.exception.BusinessException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -58,10 +59,10 @@ public class ManagerInfo {
 
     private static void validate(UUID userId, String slackId) {
         if (userId == null) {
-            throw new IllegalArgumentException("userId는 필수입니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.USER_ID_REQUIRED);
         }
         if (slackId == null || slackId.isBlank()) {
-            throw new IllegalArgumentException("slackId는 필수입니다.");
+            throw new BusinessException(DeliveryManagerErrorCode.SLACK_ID_REQUIRED);
         }
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum DeliveryManagerErrorCode implements ErrorCode {
-    DELETE_ME(HttpStatus.CONFLICT, "작성을 위한 예시입니다.");
+    USER_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 서비스 호출에 실패했습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum DeliveryManagerErrorCode implements ErrorCode {
-    USER_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 서비스 호출에 실패했습니다.");
+    USER_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 서비스 호출에 실패했습니다."),
+    DELIVERY_MANAGER_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "배송담당자는 최대 10명까지만 등록할 수 있습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
@@ -9,6 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum DeliveryManagerErrorCode implements ErrorCode {
     USER_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 서비스 호출에 실패했습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "대상 사용자를 찾을 수 없습니다."),
+    DELIVERY_MANAGER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 배송담당자입니다."),
+    DELIVERY_MANAGER_HUB_REQUIRED(HttpStatus.BAD_REQUEST, "업체 배송 담당자는 허브 정보가 필요합니다."),
+    DELIVERY_MANAGER_SLACK_ID_REQUIRED(HttpStatus.BAD_REQUEST, "슬랙 ID가 없는 사용자입니다."),
     DELIVERY_MANAGER_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "배송담당자는 최대 10명까지만 등록할 수 있습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
@@ -8,12 +8,23 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum DeliveryManagerErrorCode implements ErrorCode {
+    // internal
     USER_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 서비스 호출에 실패했습니다."),
+
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "대상 사용자를 찾을 수 없습니다."),
-    DELIVERY_MANAGER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 배송담당자입니다."),
-    DELIVERY_MANAGER_HUB_REQUIRED(HttpStatus.BAD_REQUEST, "업체 배송 담당자는 허브 정보가 필요합니다."),
-    DELIVERY_MANAGER_SLACK_ID_REQUIRED(HttpStatus.BAD_REQUEST, "슬랙 ID가 없는 사용자입니다."),
-    DELIVERY_MANAGER_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "배송담당자는 최대 10명까지만 등록할 수 있습니다.");
+
+    USER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "userId는 필수입니다."),
+    SLACK_ID_REQUIRED(HttpStatus.BAD_REQUEST, "slackId는 필수입니다."),
+    DELIVERY_MANAGER_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "배송 담당자 타입은 필수입니다."),
+    COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED(HttpStatus.BAD_REQUEST, "업체 배송 담당자는 허브 ID가 필요합니다."),
+
+    DELIVERY_MANAGER_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "배송담당자는 최대 10명까지만 등록할 수 있습니다."),
+    DELIVERY_MANAGER_SEQUENCE_INVALID(HttpStatus.BAD_REQUEST, "배송담당자 순번은 1~10 범위여야 합니다."),
+    DELIVERY_MANAGER_ALREADY_DELIVERING(HttpStatus.BAD_REQUEST, "이미 배송 중인 담당자입니다."),
+    DELETED_DELIVERY_MANAGER_CANNOT_CHANGE_STATUS(HttpStatus.BAD_REQUEST, "삭제된 배송 담당자는 배송 상태를 변경할 수 없습니다."),
+    DELIVERY_MANAGER_NOT_DELIVERING(HttpStatus.BAD_REQUEST, "배송 중인 상태가 아닙니다."),
+
+    DELIVERY_MANAGER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 배송담당자입니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerQueryRepository.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerQueryRepository.java
@@ -17,10 +17,4 @@ public interface DeliveryManagerQueryRepository {
 
     // 수정일순 목록 조회
     List<DeliveryManager> findAllByHubIdAndTypeOrderByUpdatedAtAsc(UUID hubId, DeliveryManagerType type);
-
-    // 배송담당자 생성 시 중복 생성을 막기 위해 배송담당자로 등록되었는 지 확인
-    boolean existsByUserId(UUID userId);
-
-    // 배송담당자 생성 시 다음 순번 반환
-    Integer findLastSequence(DeliveryManagerType type, UUID hubId);
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerQueryRepository.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerQueryRepository.java
@@ -17,4 +17,10 @@ public interface DeliveryManagerQueryRepository {
 
     // 수정일순 목록 조회
     List<DeliveryManager> findAllByHubIdAndTypeOrderByUpdatedAtAsc(UUID hubId, DeliveryManagerType type);
+
+    // 배송담당자 생성 시 중복 생성을 막기 위해 배송담당자로 등록되었는 지 확인
+    boolean existsByUserId(UUID userId);
+
+    // 배송담당자 생성 시 다음 순번 반환
+    Integer findLastSequence(DeliveryManagerType type, UUID hubId);
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerRepository.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerRepository.java
@@ -13,7 +13,7 @@ public interface DeliveryManagerRepository {
     // 배송담당자 생성 시 중복 생성을 막기 위해 배송담당자로 등록되었는 지 확인
     boolean existsByUserId(UUID userId);
 
-    // 배송담당자 생성 시 다음 순번 반환
+    // 배송담당자 생성 시 현재 마지막 순번 반환
     Integer findLastSequence(DeliveryManagerType type, UUID hubId);
 
     DeliveryManager save(DeliveryManager deliveryManager);

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerRepository.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerRepository.java
@@ -1,6 +1,7 @@
 package com.fhsh.daitda.deliverymanager.domain.repository;
 
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
+import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -8,6 +9,12 @@ import java.util.UUID;
 public interface DeliveryManagerRepository {
     // 배송담당자 아이디로 배송담당자 조회
     Optional<DeliveryManager> findById(UUID deliveryManagerId);
+
+    // 배송담당자 생성 시 중복 생성을 막기 위해 배송담당자로 등록되었는 지 확인
+    boolean existsByUserId(UUID userId);
+
+    // 배송담당자 생성 시 다음 순번 반환
+    Integer findLastSequence(DeliveryManagerType type, UUID hubId);
 
     DeliveryManager save(DeliveryManager deliveryManager);
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
@@ -2,12 +2,8 @@ package com.fhsh.daitda.deliverymanager.infrastructure.external;
 
 import com.fhsh.daitda.deliverymanager.application.client.UserClient;
 import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
-import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
-import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.ApiResponse;
 import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.UserResponse;
-import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.response.CommonResponse;
-import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
@@ -6,6 +6,7 @@ import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode
 import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.ApiResponse;
 import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.UserResponse;
 import com.fhsh.daitda.exception.BusinessException;
+import com.fhsh.daitda.response.CommonResponse;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,17 +21,13 @@ public class UserAdapter implements UserClient {
 
     @Override
     public UserInfoCommand getUser(UUID userId) {
-        try {
-            ApiResponse<UserResponse> apiResponse = userFeignClient.getUser(userId);
-            UserResponse response = apiResponse.data();
+        CommonResponse<UserResponse> feignResponse = userFeignClient.getUser(userId);
+        UserResponse response = feignResponse.getData();
 
-            if (response == null) {
-                return null;
-            }
-
-            return new UserInfoCommand(response.userId(), response.hubId(), response.slackUserId());
-        } catch (FeignException e) {
-            throw new BusinessException(DeliveryManagerErrorCode.USER_SERVICE_ERROR);
+        if (response == null) {
+            return null;
         }
+
+        return new UserInfoCommand(response.userId(), response.hubId(), response.slackUserId());
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
@@ -2,8 +2,11 @@ package com.fhsh.daitda.deliverymanager.infrastructure.external;
 
 import com.fhsh.daitda.deliverymanager.application.client.UserClient;
 import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
 import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.ApiResponse;
 import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.UserResponse;
+import com.fhsh.daitda.exception.BusinessException;
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -17,9 +20,17 @@ public class UserAdapter implements UserClient {
 
     @Override
     public UserInfoCommand getUser(UUID userId) {
-        ApiResponse<UserResponse> apiResponse = userFeignClient.getUser(userId);
-        UserResponse response = apiResponse.data();
+        try {
+            ApiResponse<UserResponse> apiResponse = userFeignClient.getUser(userId);
+            UserResponse response = apiResponse.data();
 
-        return new UserInfoCommand(response.userId(), response.hubId(), response.slackUserId());
+            if (response == null) {
+                return null;
+            }
+
+            return new UserInfoCommand(response.userId(), response.hubId(), response.slackUserId());
+        } catch (FeignException e) {
+            throw new BusinessException(DeliveryManagerErrorCode.USER_SERVICE_ERROR);
+        }
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
@@ -1,0 +1,25 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.external;
+
+import com.fhsh.daitda.deliverymanager.application.client.UserClient;
+import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.ApiResponse;
+import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class UserAdapter implements UserClient {
+
+    private final UserFeignClient userFeignClient;
+
+    @Override
+    public UserInfoCommand getUser(UUID userId) {
+        ApiResponse<UserResponse> apiResponse = userFeignClient.getUser(userId);
+        UserResponse response = apiResponse.data();
+
+        return new UserInfoCommand(response.userId(), response.hubId(), response.slackUserId());
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserFeignClient.java
@@ -1,0 +1,15 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.external;
+
+import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.ApiResponse;
+import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.UserResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "user-service")
+public interface UserFeignClient {
+    @GetMapping("/internal/v1/users/{userId}")
+    ApiResponse<UserResponse> getUser(@PathVariable UUID userId);
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserFeignClient.java
@@ -16,5 +16,5 @@ import java.util.UUID;
 )
 public interface UserFeignClient {
     @GetMapping("/{userId}")
-    CommonResponse<UserResponse> getUser(@PathVariable UUID userId);
+    CommonResponse<UserResponse> getUser(@PathVariable("userId") UUID userId);
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserFeignClient.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserFeignClient.java
@@ -1,15 +1,20 @@
 package com.fhsh.daitda.deliverymanager.infrastructure.external;
 
-import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.ApiResponse;
 import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.UserResponse;
+import com.fhsh.daitda.deliverymanager.infrastructure.external.fallback.UserClientFallbackFactory;
+import com.fhsh.daitda.response.CommonResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.UUID;
 
-@FeignClient(name = "user-service")
+@FeignClient(
+        name = "user-service",
+        path = "/internal/v1/users",
+        fallbackFactory = UserClientFallbackFactory.class
+)
 public interface UserFeignClient {
-    @GetMapping("/internal/v1/users/{userId}")
-    ApiResponse<UserResponse> getUser(@PathVariable UUID userId);
+    @GetMapping("/{userId}")
+    CommonResponse<UserResponse> getUser(@PathVariable UUID userId);
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/dto/ApiResponse.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/dto/ApiResponse.java
@@ -1,0 +1,7 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.external.dto;
+
+public record ApiResponse<T>(
+        int status,
+        String message,
+        T data
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/dto/UserResponse.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/dto/UserResponse.java
@@ -1,0 +1,17 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.external.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UserResponse(
+        UUID userId,
+        String email,
+        String name,
+        String role,
+        String status,
+        String slackUserId,
+        UUID hubId,
+        UUID companyId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/fallback/UserClientFallbackFactory.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/fallback/UserClientFallbackFactory.java
@@ -1,6 +1,5 @@
 package com.fhsh.daitda.deliverymanager.infrastructure.external.fallback;
 
-import com.fhsh.daitda.deliverymanager.application.client.UserClient;
 import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
 import com.fhsh.daitda.deliverymanager.infrastructure.external.UserFeignClient;
 import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.UserResponse;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/fallback/UserClientFallbackFactory.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/fallback/UserClientFallbackFactory.java
@@ -1,0 +1,31 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.external.fallback;
+
+import com.fhsh.daitda.deliverymanager.application.client.UserClient;
+import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
+import com.fhsh.daitda.deliverymanager.infrastructure.external.UserFeignClient;
+import com.fhsh.daitda.deliverymanager.infrastructure.external.dto.UserResponse;
+import com.fhsh.daitda.exception.BusinessException;
+import com.fhsh.daitda.response.CommonResponse;
+import feign.FeignException;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class UserClientFallbackFactory implements FallbackFactory<UserFeignClient> {
+
+    @Override
+    public UserFeignClient create(Throwable cause) {
+        return new UserFeignClient() {
+            @Override
+            public CommonResponse<UserResponse> getUser(UUID userId) {
+                if (cause instanceof FeignException.NotFound) {
+                    throw new BusinessException(DeliveryManagerErrorCode.USER_NOT_FOUND);
+                }
+
+                throw new BusinessException(DeliveryManagerErrorCode.USER_SERVICE_ERROR);
+            }
+        };
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -1,6 +1,7 @@
 package com.fhsh.daitda.deliverymanager.infrastructure.repository;
 
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
+import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +10,11 @@ import java.util.UUID;
 public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryManager, UUID> {
 
     Optional<DeliveryManager> findByDeliveryManagerIdAndDeletedAtIsNull(UUID deliveryManagerId);
+
+    boolean existsByManagerInfo_UserIdAndDeletedAtIsNull(UUID userId);
+
+    Optional<DeliveryManager> findFirstByTypeAndManagerInfo_HubIdAndDeletedAtIsNullOrderBySequenceDesc(
+            DeliveryManagerType type,
+            UUID hubId
+    );
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerQueryRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerQueryRepositoryImpl.java
@@ -63,6 +63,44 @@ public class DeliveryManagerQueryRepositoryImpl implements DeliveryManagerQueryR
                 .fetch();
     }
 
+    @Override
+    public boolean existsByUserId(UUID userId) {
+        Integer result = queryFactory
+                .selectOne()
+                .from(deliveryManager)
+                .where(
+                        deliveryManager.managerInfo.userId.eq(userId),
+                        deliveryManager.deletedAt.isNull()
+                )
+                .fetchFirst();
+
+        return result != null;
+    }
+
+    @Override
+    public Integer findLastSequence(DeliveryManagerType type, UUID hubId) {
+        if (type == DeliveryManagerType.COMPANY) {
+            return queryFactory
+                    .select(deliveryManager.sequence.max())
+                    .from(deliveryManager)
+                    .where(
+                            deliveryManager.type.eq(type),
+                            deliveryManager.managerInfo.hubId.eq(hubId),
+                            deliveryManager.deletedAt.isNull()
+                    )
+                    .fetchOne();
+        }
+
+        return queryFactory
+                .select(deliveryManager.sequence.max())
+                .from(deliveryManager)
+                .where(
+                        deliveryManager.type.eq(type),
+                        deliveryManager.deletedAt.isNull()
+                )
+                .fetchOne();
+    }
+
     // 삭제 여부
     private BooleanExpression isNotDeleted() {
         return deliveryManager.deletedAt.isNull();

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerQueryRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerQueryRepositoryImpl.java
@@ -63,44 +63,6 @@ public class DeliveryManagerQueryRepositoryImpl implements DeliveryManagerQueryR
                 .fetch();
     }
 
-    @Override
-    public boolean existsByUserId(UUID userId) {
-        Integer result = queryFactory
-                .selectOne()
-                .from(deliveryManager)
-                .where(
-                        deliveryManager.managerInfo.userId.eq(userId),
-                        deliveryManager.deletedAt.isNull()
-                )
-                .fetchFirst();
-
-        return result != null;
-    }
-
-    @Override
-    public Integer findLastSequence(DeliveryManagerType type, UUID hubId) {
-        if (type == DeliveryManagerType.COMPANY) {
-            return queryFactory
-                    .select(deliveryManager.sequence.max())
-                    .from(deliveryManager)
-                    .where(
-                            deliveryManager.type.eq(type),
-                            deliveryManager.managerInfo.hubId.eq(hubId),
-                            deliveryManager.deletedAt.isNull()
-                    )
-                    .fetchOne();
-        }
-
-        return queryFactory
-                .select(deliveryManager.sequence.max())
-                .from(deliveryManager)
-                .where(
-                        deliveryManager.type.eq(type),
-                        deliveryManager.deletedAt.isNull()
-                )
-                .fetchOne();
-    }
-
     // 삭제 여부
     private BooleanExpression isNotDeleted() {
         return deliveryManager.deletedAt.isNull();

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.fhsh.daitda.deliverymanager.infrastructure.repository;
 
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
+import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
 import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -17,6 +18,19 @@ public class DeliveryManagerRepositoryImpl implements DeliveryManagerRepository 
     @Override
     public Optional<DeliveryManager> findById(UUID deliveryManagerId) {
         return deliveryManagerJpaRepository.findByDeliveryManagerIdAndDeletedAtIsNull(deliveryManagerId);
+    }
+
+    @Override
+    public boolean existsByUserId(UUID userId) {
+        return deliveryManagerJpaRepository.existsByManagerInfo_UserIdAndDeletedAtIsNull(userId);
+    }
+
+    @Override
+    public Integer findLastSequence(DeliveryManagerType type, UUID hubId) {
+        return deliveryManagerJpaRepository
+                .findFirstByTypeAndManagerInfo_HubIdAndDeletedAtIsNullOrderBySequenceDesc(type, hubId)
+                .map(DeliveryManager::getSequence)
+                .orElse(0);
     }
 
     @Override

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,14 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   config:
     import: "optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888}"
+  cloud:
+    openfeign:
+      client:
+        config:
+          user-service:
+            connectTimeout: 1000 # 1초
+            readTimeout: 2000 # 2초
+
 server:
   port: ${SERVER_PORT:8084}
 

--- a/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
@@ -1,0 +1,156 @@
+package com.fhsh.daitda.deliverymanager.application.service.command;
+
+import com.fhsh.daitda.deliverymanager.application.client.UserClient;
+import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
+import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
+import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
+import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerRepository;
+import com.fhsh.daitda.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class DeliveryManagerCommandServiceTest {
+
+    @InjectMocks
+    private DeliveryManagerCommandService managerService;
+
+    @Mock
+    private DeliveryManagerRepository managerRepository;
+    @Mock
+    private UserClient userClient;
+
+    @Nested
+    @DisplayName("배송담당자 생성")
+    class CreateDeliveryManager {
+
+        @Test
+        @DisplayName("정상 생성 케이스 - 마지막 순번에서 1 증가")
+        void createDeliveryManager_success() throws Exception {
+            // given
+            UUID targetUserId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            // 예시 입력값
+            CreateDeliveryManagerCommand command = new CreateDeliveryManagerCommand(targetUserId, DeliveryManagerType.COMPANY);
+
+            // 예시 사용자 정보
+            UserInfoCommand userInfo = new UserInfoCommand(targetUserId, hubId, "exampleId");
+
+            given(userClient.getUser(targetUserId)).willReturn(userInfo);
+            given(managerRepository.existsByUserId(targetUserId)).willReturn(false);
+            given(managerRepository.findLastSequence(DeliveryManagerType.COMPANY, hubId)).willReturn(7); // 현재 마지막 순번 7번
+
+            // when
+            managerService.createDeliveryManager(command);
+
+            // then
+            ArgumentCaptor<DeliveryManager> captor = ArgumentCaptor.forClass(DeliveryManager.class);
+            verify(managerRepository).save(captor.capture());
+
+            // save 시점을 캡쳐한 결과 확인
+            DeliveryManager saved = captor.getValue();
+            assertThat(readField(saved, "sequence")).isEqualTo(8); // 생성 순번 8번
+            assertThat(readField(saved, "type")).isEqualTo(DeliveryManagerType.COMPANY);
+        }
+
+        @Test
+        @DisplayName("생성 실패 케이스 - 배송담당자 10명 이후 추가 생성")
+        void createDeliveryManager_fail_LastSequenceIs10() {
+            // given
+            UUID targetUserId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            CreateDeliveryManagerCommand command = new CreateDeliveryManagerCommand(targetUserId, DeliveryManagerType.COMPANY);
+
+            UserInfoCommand userInfo = new UserInfoCommand(targetUserId, hubId, "exampleId");
+
+            given(userClient.getUser(targetUserId)).willReturn(userInfo);
+            given(managerRepository.existsByUserId(targetUserId)).willReturn(false);
+            given(managerRepository.findLastSequence(DeliveryManagerType.COMPANY, hubId)).willReturn(10); // 현재 마지막 순번 10번
+
+            // when & then
+            // 10명 생성 초과 오류 발생
+            assertThatThrownBy(() -> managerService.createDeliveryManager(command))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(DeliveryManagerErrorCode.DELIVERY_MANAGER_LIMIT_EXCEEDED);
+
+            verify(managerRepository, never()).save(any(DeliveryManager.class));
+        }
+
+        @Test
+        @DisplayName("생성 실패 케이스 - 이미 등록된 배송담당자")
+        void createDeliveryManager_fail_alreadyExists() {
+            // given
+            UUID targetUserId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            CreateDeliveryManagerCommand command =
+                    new CreateDeliveryManagerCommand(targetUserId, DeliveryManagerType.COMPANY);
+
+            UserInfoCommand userInfo =
+                    new UserInfoCommand(targetUserId, hubId, "exampleId");
+
+            given(userClient.getUser(targetUserId)).willReturn(userInfo);
+            // 해당 userId의 배송담당자가 이미 존재하므로 true 반환
+            given(managerRepository.existsByUserId(targetUserId)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> managerService.createDeliveryManager(command))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(DeliveryManagerErrorCode.DELIVERY_MANAGER_ALREADY_EXISTS);
+
+            verify(managerRepository, never()).save(any(DeliveryManager.class));
+        }
+
+        @Test
+        @DisplayName("생성 실패 케이스 - 업체 배송 담당자의 허브 정보 누락")
+        void createDeliveryManager_fail_companyWithoutHub() {
+            // given
+            UUID targetUserId = UUID.randomUUID();
+
+            CreateDeliveryManagerCommand command =
+                    new CreateDeliveryManagerCommand(targetUserId, DeliveryManagerType.COMPANY);
+
+            UserInfoCommand userInfo =
+                    new UserInfoCommand(targetUserId, null, "exampleId");
+
+            given(userClient.getUser(targetUserId)).willReturn(userInfo);
+
+            // when & then
+            assertThatThrownBy(() -> managerService.createDeliveryManager(command))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(DeliveryManagerErrorCode.DELIVERY_MANAGER_HUB_REQUIRED);
+
+            verify(managerRepository, never()).save(any(DeliveryManager.class));
+        }
+    }
+
+    // 자바 리플렉션 기능을 이용해 private 필드 값을 꺼냄
+    private Object readField(Object target, String fieldName) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}

--- a/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
@@ -141,7 +141,7 @@ public class DeliveryManagerCommandServiceTest {
             assertThatThrownBy(() -> managerService.createDeliveryManager(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
-                    .isEqualTo(DeliveryManagerErrorCode.DELIVERY_MANAGER_HUB_REQUIRED);
+                    .isEqualTo(DeliveryManagerErrorCode.COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED);
 
             verify(managerRepository, never()).save(any(DeliveryManager.class));
         }

--- a/src/test/java/com/fhsh/daitda/deliverymanager/domain/entity/AssignmentCursorTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/domain/entity/AssignmentCursorTest.java
@@ -1,6 +1,8 @@
 package com.fhsh.daitda.deliverymanager.domain.entity;
 
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
+import com.fhsh.daitda.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -33,8 +35,9 @@ public class AssignmentCursorTest {
         AssignmentCursor cursor = AssignmentCursor.init(DeliveryManagerType.HUB, null);
 
         assertThatThrownBy(() -> cursor.advanceTo(0))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("유효하지 않은 담당자 순번입니다.");
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(DeliveryManagerErrorCode.DELIVERY_MANAGER_SEQUENCE_INVALID);
     }
 
     @Test
@@ -43,15 +46,17 @@ public class AssignmentCursorTest {
         AssignmentCursor cursor = AssignmentCursor.init(DeliveryManagerType.HUB, null);
 
         assertThatThrownBy(() -> cursor.advanceTo(11))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("유효하지 않은 담당자 순번입니다.");
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(DeliveryManagerErrorCode.DELIVERY_MANAGER_SEQUENCE_INVALID);
     }
 
     @Test
     @DisplayName("업체 배송 담당자 커서는 허브 ID가 없으면 예외 발생")
     void init_fail_whenCompanyHubIdIsNull() {
         assertThatThrownBy(() -> AssignmentCursor.init(DeliveryManagerType.COMPANY, null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("업체 배송 담당자 커서는 허브 ID가 필요합니다.");
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(DeliveryManagerErrorCode.COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED);
     }
 }

--- a/src/test/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManagerTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManagerTest.java
@@ -1,6 +1,8 @@
 package com.fhsh.daitda.deliverymanager.domain.entity;
 
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
+import com.fhsh.daitda.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -43,8 +45,9 @@ public class DeliveryManagerTest {
                         DeliveryManagerType.COMPANY,
                         1
                 )
-        ).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("업체 배송 담당자는 허브 ID가 필수입니다.");
+        ).isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(DeliveryManagerErrorCode.COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED);
     }
 
     @Test


### PR DESCRIPTION
## 🌱 설명

- FeignClient 설정 추가
- 배송담당자 생성 서비스 로직에서 내부 통신 적용

## 📌 관련 이슈

- close #5 

## ✅ 주요 변경 사항

- user service와 소통할 FeignClient 적용을 위해 application 계층에서 UserClient 인터페이스 정의
- infrastructure 계층에서 UserClient를 구현한 UserAdapter 생성 및 UserFeignClient 인터페이스 정의
- 서비스 로직 중 배송담당자 생성 구현
- 배송담당자 생성 시 중복 생성을 막기 위해 검증 조건 추가 구현 및 적용, userId 유니크 제약 명시
- 배송담당자 생성 순번을 지정하기 위해 다음 순번 반환 기능 추가 구현
- 배송담당자 생성 테스트 코드 추가
- 기존 에러 처리를 비즈니스 에러 코드 사용으로 변경

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 배송담당자의 배정 순번은 AssignmentCursor에서 관리하지만, 생성 순번을 관리하는 커서는 따로 없어 로직 상에서 생성 순서대로 부여하도록 구현하였습니다.
- ApiResponse는 추후 common 모듈의 CommonResponse 생성자 설정 추가 후 CommonResponse로 교체하여 적용할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 배송 관리자 등록 흐름 추가(생성 명령, 타입·시퀀스 관리, 외부 사용자 조회 및 응답 매핑)
  * 외부 사용자 연동용 클라이언트와 페인(Fallback) 처리 추가
  * 내부 API 응답 포맷 및 저장소 조회 기능 확장(마지막 시퀀스 조회 등)

* **Bug Fixes**
  * 중복 등록 방지 및 user_id 유니크 제약 적용
  * 검증 실패 시 일관된 도메인 오류 코드로 변경 및 에러 정비

* **Tests**
  * 배송 관리자 생성 관련 단위 테스트 추가(성공 및 주요 실패 시나리오)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->