### PR TITLE
Feat: 배송 완료 API, 배송담당자 배정 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext {
 }
 
 dependencies {
-	implementation 'com.fhsh.daitda:common:0.1.3-SNAPSHOT'
+	implementation 'com.fhsh.daitda:common:0.1.4-SNAPSHOT'
 
 	// config server 연결
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/command/CompleteAssignmentCommand.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/command/CompleteAssignmentCommand.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.deliverymanager.application.command;
+
+import java.util.UUID;
+
+public record CompleteAssignmentCommand(
+        UUID deliveryId,
+        UUID hubId
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/command/CompleteCurrentDeliveryCommand.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/command/CompleteCurrentDeliveryCommand.java
@@ -4,5 +4,5 @@ import java.util.UUID;
 
 public record CompleteCurrentDeliveryCommand(
         UUID deliveryId,
-        UUID deliveryManagerId
+        UUID userId
 ) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/command/CompleteCurrentDeliveryCommand.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/command/CompleteCurrentDeliveryCommand.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.deliverymanager.application.command;
+
+import java.util.UUID;
+
+public record CompleteCurrentDeliveryCommand(
+        UUID deliveryId,
+        UUID deliveryManagerId
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/result/CompleteAssignmentResult.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/result/CompleteAssignmentResult.java
@@ -1,0 +1,31 @@
+package com.fhsh.daitda.deliverymanager.application.result;
+
+import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
+import com.fhsh.daitda.deliverymanager.domain.entity.ManagerInfo;
+import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record CompleteAssignmentResult(
+        UUID deliveryManagerId,
+        UUID userId,
+        UUID hubId,
+        String slackId,
+        DeliveryManagerType type,
+        int sequence
+) {
+    public static CompleteAssignmentResult from(DeliveryManager deliveryManager) {
+        ManagerInfo managerInfo = deliveryManager.getManagerInfo();
+
+        return CompleteAssignmentResult.builder()
+                .deliveryManagerId(deliveryManager.getDeliveryManagerId())
+                .userId(managerInfo != null ? managerInfo.getUserId() : null)
+                .hubId(managerInfo != null ? managerInfo.getHubId() : null)
+                .slackId(managerInfo != null ? managerInfo.getSlackId() : null)
+                .type(deliveryManager.getType())
+                .sequence(deliveryManager.getSequence())
+                .build();
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/result/CompleteAssignmentResult.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/result/CompleteAssignmentResult.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 @Builder
 public record CompleteAssignmentResult(
+        UUID deliveryId,
         UUID deliveryManagerId,
         UUID userId,
         UUID hubId,
@@ -16,10 +17,11 @@ public record CompleteAssignmentResult(
         DeliveryManagerType type,
         int sequence
 ) {
-    public static CompleteAssignmentResult from(DeliveryManager deliveryManager) {
+    public static CompleteAssignmentResult from(DeliveryManager deliveryManager, UUID deliveryId) {
         ManagerInfo managerInfo = deliveryManager.getManagerInfo();
 
         return CompleteAssignmentResult.builder()
+                .deliveryId(deliveryId)
                 .deliveryManagerId(deliveryManager.getDeliveryManagerId())
                 .userId(managerInfo != null ? managerInfo.getUserId() : null)
                 .hubId(managerInfo != null ? managerInfo.getHubId() : null)

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/result/CompleteCurrentDeliveryResult.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/result/CompleteCurrentDeliveryResult.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.deliverymanager.application.result;
+
+import java.util.UUID;
+
+public record CompleteCurrentDeliveryResult(
+    UUID deliveryId,
+    boolean isDelivery
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -80,7 +80,7 @@ public class DeliveryManagerCommandService {
 
     // 배송담당자 배송 완료
     public CompleteCurrentDeliveryResult completeCurrentDelivery(CompleteCurrentDeliveryCommand command) {
-        DeliveryManager deliveryManager = deliveryManagerRepository.findById(command.userId())
+        DeliveryManager deliveryManager = deliveryManagerRepository.findByUserId(command.userId())
                 .orElseThrow(() -> new BusinessException(DeliveryManagerErrorCode.USER_NOT_FOUND));
 
         // 배송 완료로 변경

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -112,7 +112,7 @@ public class DeliveryManagerCommandService {
         // 커서 갱신
         cursor.advanceTo(deliveryManager.getSequence());
 
-        return CompleteAssignmentResult.from(deliveryManager);
+        return CompleteAssignmentResult.from(deliveryManager, command.deliveryId());
     }
 
     private void validateUser(UserInfoCommand userInfo, CreateDeliveryManagerCommand command) {

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -69,7 +69,7 @@ public class DeliveryManagerCommandService {
     }
 
     // 배송담당자 삭제
-    public DeleteDeliveryManagerResult deleteDeliveryManager(String userId, UUID deliveryManagerId) {
+    public DeleteDeliveryManagerResult deleteDeliveryManager(UUID userId, UUID deliveryManagerId) {
         DeliveryManager deliveryManager = deliveryManagerRepository.findById(deliveryManagerId)
                 .orElseThrow(() -> new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_FOUND));
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -1,8 +1,10 @@
 package com.fhsh.daitda.deliverymanager.application.service.command;
 
 import com.fhsh.daitda.deliverymanager.application.client.UserLookupService;
+import com.fhsh.daitda.deliverymanager.application.command.CompleteCurrentDeliveryCommand;
 import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
 import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+import com.fhsh.daitda.deliverymanager.application.result.CompleteCurrentDeliveryResult;
 import com.fhsh.daitda.deliverymanager.application.result.CreateDeliveryManagerResult;
 import com.fhsh.daitda.deliverymanager.application.result.DeleteDeliveryManagerResult;
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
@@ -24,6 +26,7 @@ public class DeliveryManagerCommandService {
     private final DeliveryManagerRepository deliveryManagerRepository;
     private final UserLookupService userLookupService;
 
+    // 배송담당자 생성
     public CreateDeliveryManagerResult createDeliveryManager(CreateDeliveryManagerCommand command) {
         // user-service에서 사용자 정보 받아오기
         UserInfoCommand userInfo = userLookupService.getUser(command.targetUserId());
@@ -58,6 +61,7 @@ public class DeliveryManagerCommandService {
         return new CreateDeliveryManagerResult(saved.getDeliveryManagerId());
     }
 
+    // 배송담당자 삭제
     public DeleteDeliveryManagerResult deleteDeliveryManager(String userId, UUID deliveryManagerId) {
         DeliveryManager deliveryManager = deliveryManagerRepository.findById(deliveryManagerId)
                 .orElseThrow(() -> new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_FOUND));
@@ -65,6 +69,19 @@ public class DeliveryManagerCommandService {
         deliveryManager.delete(userId);
 
         return new DeleteDeliveryManagerResult(deliveryManager.getDeliveryManagerId());
+    }
+
+    // 배송담당자 배송 완료
+    public CompleteCurrentDeliveryResult completeCurrentDelivery(CompleteCurrentDeliveryCommand command) {
+        DeliveryManager deliveryManager = deliveryManagerRepository.findById(command.deliveryManagerId())
+                .orElseThrow(() -> new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_FOUND));
+
+        // 배송 완료로 변경
+        deliveryManager.completeDelivery();
+
+        // 배송 완료 메시지 발행 필요
+
+        return new CompleteCurrentDeliveryResult(command.deliveryId(), deliveryManager.isDelivery());
     }
 
     private void validateUser(UserInfoCommand userInfo, CreateDeliveryManagerCommand command) {

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -1,15 +1,20 @@
 package com.fhsh.daitda.deliverymanager.application.service.command;
 
 import com.fhsh.daitda.deliverymanager.application.client.UserLookupService;
+import com.fhsh.daitda.deliverymanager.application.command.CompleteAssignmentCommand;
 import com.fhsh.daitda.deliverymanager.application.command.CompleteCurrentDeliveryCommand;
 import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
 import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+import com.fhsh.daitda.deliverymanager.application.result.CompleteAssignmentResult;
 import com.fhsh.daitda.deliverymanager.application.result.CompleteCurrentDeliveryResult;
 import com.fhsh.daitda.deliverymanager.application.result.CreateDeliveryManagerResult;
 import com.fhsh.daitda.deliverymanager.application.result.DeleteDeliveryManagerResult;
+import com.fhsh.daitda.deliverymanager.domain.entity.AssignmentCursor;
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
 import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
+import com.fhsh.daitda.deliverymanager.domain.repository.AssignmentCursorRepository;
+import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerAssignmentRepository;
 import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerRepository;
 import com.fhsh.daitda.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +30,8 @@ public class DeliveryManagerCommandService {
 
     private final DeliveryManagerRepository deliveryManagerRepository;
     private final UserLookupService userLookupService;
+    private final DeliveryManagerAssignmentRepository deliveryManagerAssignmentRepository;
+    private final AssignmentCursorRepository assignmentCursorRepository;
 
     // 배송담당자 생성
     public CreateDeliveryManagerResult createDeliveryManager(CreateDeliveryManagerCommand command) {
@@ -82,6 +89,30 @@ public class DeliveryManagerCommandService {
         // 배송 완료 메시지 발행 필요
 
         return new CompleteCurrentDeliveryResult(command.deliveryId(), deliveryManager.isDelivery());
+    }
+
+    // 배송담당자 배정
+    public CompleteAssignmentResult completeAssignment(CompleteAssignmentCommand command) {
+        DeliveryManagerType type =
+                (command.hubId() == null) ? DeliveryManagerType.HUB : DeliveryManagerType.COMPANY;
+
+        // 지정된 타입과 허브에 맞는 커서 찾기
+        // 커서가 없다면 생성/저장하여 반환
+        AssignmentCursor cursor = assignmentCursorRepository.findByTypeAndHubId(type, command.hubId())
+                .orElseGet(() -> assignmentCursorRepository.save(AssignmentCursor.init(type, command.hubId())));
+
+        // 배정을 시작해야하는 시작 위치 받아오기
+        int startSequence = cursor.nextStartSequence();
+
+        // 지정된 타입과 허브에서 시작 위치부터 배정 순번 받아오기
+        DeliveryManager deliveryManager = deliveryManagerAssignmentRepository
+                .findNextAssignable(type, command.hubId(), startSequence)
+                .orElseThrow(() -> new BusinessException(DeliveryManagerErrorCode.NO_AVAILABLE_DELIVERY_MANAGER));
+
+        // 커서 갱신
+        cursor.advanceTo(deliveryManager.getSequence());
+
+        return CompleteAssignmentResult.from(deliveryManager);
     }
 
     private void validateUser(UserInfoCommand userInfo, CreateDeliveryManagerCommand command) {

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -80,8 +80,8 @@ public class DeliveryManagerCommandService {
 
     // 배송담당자 배송 완료
     public CompleteCurrentDeliveryResult completeCurrentDelivery(CompleteCurrentDeliveryCommand command) {
-        DeliveryManager deliveryManager = deliveryManagerRepository.findById(command.deliveryManagerId())
-                .orElseThrow(() -> new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_FOUND));
+        DeliveryManager deliveryManager = deliveryManagerRepository.findById(command.userId())
+                .orElseThrow(() -> new BusinessException(DeliveryManagerErrorCode.USER_NOT_FOUND));
 
         // 배송 완료로 변경
         deliveryManager.completeDelivery();

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
@@ -103,7 +103,7 @@ public class DeliveryManager extends BaseUserEntity {
     }
 
     // 배송담당자 삭제
-    public void delete(String deletedBy) {
+    public void delete(UUID deletedBy) {
         super.delete(deletedBy);
     }
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
@@ -24,6 +24,7 @@ public enum DeliveryManagerErrorCode implements ErrorCode {
     DELIVERY_MANAGER_ALREADY_DELIVERING(HttpStatus.BAD_REQUEST, "이미 배송 중인 담당자입니다."),
     DELETED_DELIVERY_MANAGER_CANNOT_CHANGE_STATUS(HttpStatus.BAD_REQUEST, "삭제된 배송 담당자는 배송 상태를 변경할 수 없습니다."),
     DELIVERY_MANAGER_NOT_DELIVERING(HttpStatus.BAD_REQUEST, "배송 중인 상태가 아닙니다."),
+    NO_AVAILABLE_DELIVERY_MANAGER(HttpStatus.BAD_REQUEST, "현재 배정 가능한 배송담당자가 없습니다."),
 
     DELIVERY_MANAGER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 배송담당자입니다.");
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerRepository.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/repository/DeliveryManagerRepository.java
@@ -10,6 +10,9 @@ public interface DeliveryManagerRepository {
     // 배송담당자 아이디로 배송담당자 조회
     Optional<DeliveryManager> findById(UUID deliveryManagerId);
 
+    // 사용자 아이디로 배송담당자 조회
+    Optional<DeliveryManager> findByUserId(UUID userId);
+
     // 배송담당자 생성 시 중복 생성을 막기 위해 배송담당자로 등록되었는 지 확인
     boolean existsByUserId(UUID userId);
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerAssignmentRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerAssignmentRepositoryImpl.java
@@ -30,23 +30,24 @@ public class DeliveryManagerAssignmentRepositoryImpl implements DeliveryManagerA
                         typeEq(type),
                         hubIdEq(type, hubId),
                         notDeleted(),
-                        notDelivering(),
-                        sequenceFrom(startSequence)
+                        sequenceBetween(startSequence, 10)
                 )
                 .orderBy(deliveryManager.sequence.asc())
                 .fetchFirst();
 
+        // 시작 번호 ~ 10번 중 찾은 경우
         if (candidate != null) {
             return Optional.of(candidate);
         }
 
+        // 1번 ~ 시작 번호 전 중 찾도록 다시 순회
         DeliveryManager wrappedCandidate = queryFactory
                 .selectFrom(deliveryManager)
                 .where(
                         typeEq(type),
                         hubIdEq(type, hubId),
                         notDeleted(),
-                        notDelivering()
+                        sequenceBetween(1, startSequence - 1)
                 )
                 .orderBy(deliveryManager.sequence.asc())
                 .fetchFirst();
@@ -69,11 +70,7 @@ public class DeliveryManagerAssignmentRepositoryImpl implements DeliveryManagerA
         return deliveryManager.deletedAt.isNull();
     }
 
-    private BooleanExpression notDelivering() {
-        return deliveryManager.isDelivery.isFalse();
-    }
-
-    private BooleanExpression sequenceFrom(int startSequence) {
-        return deliveryManager.sequence.goe(startSequence);
+    private BooleanExpression sequenceBetween(int start, int end) {
+        return deliveryManager.sequence.between(start, end);
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerJpaRepository.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerJpaRepository.java
@@ -11,6 +11,8 @@ public interface DeliveryManagerJpaRepository extends JpaRepository<DeliveryMana
 
     Optional<DeliveryManager> findByDeliveryManagerIdAndDeletedAtIsNull(UUID deliveryManagerId);
 
+    Optional<DeliveryManager> findByManagerInfoUserIdAndDeletedAtIsNull(UUID userId);
+
     boolean existsByManagerInfo_UserIdAndDeletedAtIsNull(UUID userId);
 
     Optional<DeliveryManager> findFirstByTypeAndManagerInfo_HubIdAndDeletedAtIsNullOrderBySequenceDesc(

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/repository/DeliveryManagerRepositoryImpl.java
@@ -21,6 +21,11 @@ public class DeliveryManagerRepositoryImpl implements DeliveryManagerRepository 
     }
 
     @Override
+    public Optional<DeliveryManager> findByUserId(UUID userId) {
+        return deliveryManagerJpaRepository.findByManagerInfoUserIdAndDeletedAtIsNull(userId);
+    }
+
+    @Override
     public boolean existsByUserId(UUID userId) {
         return deliveryManagerJpaRepository.existsByManagerInfo_UserIdAndDeletedAtIsNull(userId);
     }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
@@ -23,9 +23,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/delivery-managers")
-@RestController
 public class DeliveryManagerController {
 
     private final DeliveryManagerCommandService commandService;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
@@ -53,7 +53,7 @@ public class DeliveryManagerController {
     // 배송담당자 삭제
     @DeleteMapping("/{deliveryManagerId}")
     public ResponseEntity<CommonResponse<DeleteDeliveryManagerResponse>> deleteDeliveryManager(
-            @RequestHeader(value = "X-User-Id") String userId,
+            @RequestHeader(value = "X-User-Id") UUID userId,
             @RequestHeader(value = "X-User-Role") String role,
             @PathVariable UUID deliveryManagerId) {
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
@@ -149,7 +149,7 @@ public class DeliveryManagerController {
 
     // 권한 체크
     private boolean hasAdminOrHubRole(String role) {
-        return "ADMIN".equals(role) || "HUB".equals(role);
+        return "ADMIN".equals(role) || "HUB_ADMIN".equals(role);
     }
 
     // 권한 검증 실패 시 응답

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
@@ -141,7 +141,7 @@ public class DeliveryManagerController {
 
         CompleteCurrentDeliveryCommand command = new CompleteCurrentDeliveryCommand(deliveryId, userId);
         CompleteCurrentDeliveryResult result = commandService.completeCurrentDelivery(command);
-        CompleteCurrentDeliveryResponse response = new CompleteCurrentDeliveryResponse(result.deliveryId());
+        CompleteCurrentDeliveryResponse response = new CompleteCurrentDeliveryResponse(result.deliveryId(), result.isDelivery());
 
         return ResponseEntity.ok(CommonResponse.success(response));
     }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
@@ -89,6 +89,7 @@ public class DeliveryManagerController {
     public ResponseEntity<CommonResponse<Page<GetDeliveryManagerListResponse>>> getDeliveryManagers(
             @RequestHeader(value = "X-User-Role") String role,
             @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
             @ModelAttribute GetDeliveryManagerListRequest request
     ) {
         if (!hasAdminOrHubRole(role)) {
@@ -96,7 +97,7 @@ public class DeliveryManagerController {
         }
 
         Sort sort = getSort(request.getSortBy());
-        Pageable pageable = PageRequest.of(page, 10, sort);
+        Pageable pageable = PageRequest.of(page, size, sort);
 
         GetDeliveryManagerListQuery query = GetDeliveryManagerListQuery.from(request);
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
@@ -1,13 +1,11 @@
 package com.fhsh.daitda.deliverymanager.presentation.controller;
 
 import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
+import com.fhsh.daitda.deliverymanager.application.command.CompleteCurrentDeliveryCommand;
 import com.fhsh.daitda.deliverymanager.application.query.GetDeliveryManagerListQuery;
 import com.fhsh.daitda.deliverymanager.application.query.GetDeliveryManagerQuery;
 import com.fhsh.daitda.deliverymanager.application.query.GetMyDeliveryManagerQuery;
-import com.fhsh.daitda.deliverymanager.application.result.CreateDeliveryManagerResult;
-import com.fhsh.daitda.deliverymanager.application.result.DeleteDeliveryManagerResult;
-import com.fhsh.daitda.deliverymanager.application.result.GetDeliveryManagerResult;
-import com.fhsh.daitda.deliverymanager.application.result.GetMyDeliveryManagerResult;
+import com.fhsh.daitda.deliverymanager.application.result.*;
 import com.fhsh.daitda.deliverymanager.application.service.command.DeliveryManagerCommandService;
 import com.fhsh.daitda.deliverymanager.application.service.query.DeliveryManagerQueryService;
 import com.fhsh.daitda.deliverymanager.presentation.dto.request.CreateDeliveryManagerRequest;
@@ -124,6 +122,26 @@ public class DeliveryManagerController {
         GetMyDeliveryManagerQuery query = new GetMyDeliveryManagerQuery(userId);
         GetMyDeliveryManagerResult result = queryService.getMyDeliveryManager(query);
         GetMyDeliveryManagerResponse response = GetMyDeliveryManagerResponse.from(result);
+
+        return ResponseEntity.ok(CommonResponse.success(response));
+    }
+
+    // 배송담당자 배송 완료
+    @PatchMapping("/me/deliveries/{deliveryId}/complete")
+    public ResponseEntity<CommonResponse<CompleteCurrentDeliveryResponse>> completeCurrentDelivery(
+            @RequestHeader(value = "X-User-Id") UUID userId,
+            @RequestHeader(value = "X-User-Role") String role,
+            @PathVariable UUID deliveryId
+    ) {
+        if (!"DELIVERY".equals(role)) {
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(CommonResponse.fail(403, "접근 권한이 없습니다.", null));
+        }
+
+        CompleteCurrentDeliveryCommand command = new CompleteCurrentDeliveryCommand(deliveryId, userId);
+        CompleteCurrentDeliveryResult result = commandService.completeCurrentDelivery(command);
+        CompleteCurrentDeliveryResponse response = new CompleteCurrentDeliveryResponse(result.deliveryId());
 
         return ResponseEntity.ok(CommonResponse.success(response));
     }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/DeliveryManagerController.java
@@ -1,7 +1,7 @@
 package com.fhsh.daitda.deliverymanager.presentation.controller;
 
-import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
 import com.fhsh.daitda.deliverymanager.application.command.CompleteCurrentDeliveryCommand;
+import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
 import com.fhsh.daitda.deliverymanager.application.query.GetDeliveryManagerListQuery;
 import com.fhsh.daitda.deliverymanager.application.query.GetDeliveryManagerQuery;
 import com.fhsh.daitda.deliverymanager.application.query.GetMyDeliveryManagerQuery;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
@@ -19,7 +19,7 @@ public class DeliveryManagerInternalController {
     private final DeliveryManagerCommandService commandService;
 
     @PostMapping("/assignments")
-    public ResponseEntity<CommonResponse<CompleteAssignmentResponse>> getUserById(
+    public ResponseEntity<CommonResponse<CompleteAssignmentResponse>> completeAssignment(
             @RequestHeader(value = "X-User-Role") String role,
             @RequestBody CompleteAssignmentRequest request
     ) {

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
@@ -24,7 +24,7 @@ public class DeliveryManagerInternalController {
             @RequestBody CompleteAssignmentRequest request
     ) {
 
-        if (!("ADMIN".equals(role) || "HUB".equals(role))) {
+        if (!("ADMIN".equals(role) || "HUB_ADMIN".equals(role))) {
             return ResponseEntity
                     .status(HttpStatus.FORBIDDEN)
                     .body(CommonResponse.fail(403, "접근 권한이 없습니다.", null));

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
@@ -1,0 +1,40 @@
+package com.fhsh.daitda.deliverymanager.presentation.controller.internal;
+
+import com.fhsh.daitda.deliverymanager.application.command.CompleteAssignmentCommand;
+import com.fhsh.daitda.deliverymanager.application.result.CompleteAssignmentResult;
+import com.fhsh.daitda.deliverymanager.application.service.command.DeliveryManagerCommandService;
+import com.fhsh.daitda.deliverymanager.presentation.dto.request.CompleteAssignmentRequest;
+import com.fhsh.daitda.deliverymanager.presentation.dto.response.CompleteAssignmentResponse;
+import com.fhsh.daitda.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/delivery-managers")
+public class DeliveryManagerInternalController {
+
+    private static DeliveryManagerCommandService commandService;
+
+    @PostMapping("/assignments")
+    public ResponseEntity<CommonResponse<CompleteAssignmentResponse>> getUserById(
+            @RequestHeader(value = "X-User-Role") String role,
+            @RequestBody CompleteAssignmentRequest request
+    ) {
+
+        if (!("ADMIN".equals(role) || "HUB".equals(role))) {
+            return ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(CommonResponse.fail(403, "접근 권한이 없습니다.", null));
+        }
+
+
+        CompleteAssignmentCommand command = new CompleteAssignmentCommand(request.deliveryId(), request.hubId());
+        CompleteAssignmentResult result = commandService.completeAssignment(command);
+        CompleteAssignmentResponse response = CompleteAssignmentResponse.from(result);
+
+        return ResponseEntity.ok(CommonResponse.success("배송담당자 배정이 완료되었습니다.", response));
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
@@ -7,9 +7,11 @@ import com.fhsh.daitda.deliverymanager.presentation.dto.request.CompleteAssignme
 import com.fhsh.daitda.deliverymanager.presentation.dto.response.CompleteAssignmentResponse;
 import com.fhsh.daitda.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,16 +22,8 @@ public class DeliveryManagerInternalController {
 
     @PostMapping("/assignments")
     public ResponseEntity<CommonResponse<CompleteAssignmentResponse>> completeAssignment(
-            @RequestHeader(value = "X-User-Role") String role,
             @RequestBody CompleteAssignmentRequest request
     ) {
-
-        if (!("ADMIN".equals(role) || "HUB_ADMIN".equals(role))) {
-            return ResponseEntity
-                    .status(HttpStatus.FORBIDDEN)
-                    .body(CommonResponse.fail(403, "접근 권한이 없습니다.", null));
-        }
-
 
         CompleteAssignmentCommand command = new CompleteAssignmentCommand(request.deliveryId(), request.hubId());
         CompleteAssignmentResult result = commandService.completeAssignment(command);

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/controller/internal/DeliveryManagerInternalController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/internal/v1/delivery-managers")
 public class DeliveryManagerInternalController {
 
-    private static DeliveryManagerCommandService commandService;
+    private final DeliveryManagerCommandService commandService;
 
     @PostMapping("/assignments")
     public ResponseEntity<CommonResponse<CompleteAssignmentResponse>> getUserById(

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/request/CompleteAssignmentRequest.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/request/CompleteAssignmentRequest.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.deliverymanager.presentation.dto.request;
+
+import java.util.UUID;
+
+public record CompleteAssignmentRequest(
+    UUID deliveryId,
+    UUID hubId
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/response/CompleteAssignmentResponse.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/response/CompleteAssignmentResponse.java
@@ -1,7 +1,6 @@
 package com.fhsh.daitda.deliverymanager.presentation.dto.response;
 
 import com.fhsh.daitda.deliverymanager.application.result.CompleteAssignmentResult;
-import com.fhsh.daitda.deliverymanager.application.result.GetDeliveryManagerResult;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
 import lombok.Builder;
 
@@ -9,6 +8,7 @@ import java.util.UUID;
 
 @Builder
 public record CompleteAssignmentResponse(
+        UUID deliveryId,
         UUID deliveryManagerId,
         UUID userId,
         UUID hubId,
@@ -18,6 +18,7 @@ public record CompleteAssignmentResponse(
 ) {
     public static CompleteAssignmentResponse from(CompleteAssignmentResult result) {
         return CompleteAssignmentResponse.builder()
+                .deliveryId(result.deliveryId())
                 .deliveryManagerId(result.deliveryManagerId())
                 .userId(result.userId())
                 .hubId(result.hubId())

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/response/CompleteAssignmentResponse.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/response/CompleteAssignmentResponse.java
@@ -1,0 +1,29 @@
+package com.fhsh.daitda.deliverymanager.presentation.dto.response;
+
+import com.fhsh.daitda.deliverymanager.application.result.CompleteAssignmentResult;
+import com.fhsh.daitda.deliverymanager.application.result.GetDeliveryManagerResult;
+import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
+import lombok.Builder;
+
+import java.util.UUID;
+
+@Builder
+public record CompleteAssignmentResponse(
+        UUID deliveryManagerId,
+        UUID userId,
+        UUID hubId,
+        String slackId,
+        DeliveryManagerType type,
+        int sequence
+) {
+    public static CompleteAssignmentResponse from(CompleteAssignmentResult result) {
+        return CompleteAssignmentResponse.builder()
+                .deliveryManagerId(result.deliveryManagerId())
+                .userId(result.userId())
+                .hubId(result.hubId())
+                .slackId(result.slackId())
+                .type(result.type())
+                .sequence(result.sequence())
+                .build();
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/response/CompleteCurrentDeliveryResponse.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/response/CompleteCurrentDeliveryResponse.java
@@ -3,5 +3,6 @@ package com.fhsh.daitda.deliverymanager.presentation.dto.response;
 import java.util.UUID;
 
 public record CompleteCurrentDeliveryResponse(
-        UUID deliveryId
+        UUID deliveryId,
+        boolean isDelivery
 ) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/response/CompleteCurrentDeliveryResponse.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/presentation/dto/response/CompleteCurrentDeliveryResponse.java
@@ -1,0 +1,7 @@
+package com.fhsh.daitda.deliverymanager.presentation.dto.response;
+
+import java.util.UUID;
+
+public record CompleteCurrentDeliveryResponse(
+        UUID deliveryId
+) { }

--- a/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
@@ -1,8 +1,10 @@
 package com.fhsh.daitda.deliverymanager.application.service.command;
 
 import com.fhsh.daitda.deliverymanager.application.client.UserLookupService;
+import com.fhsh.daitda.deliverymanager.application.command.CompleteCurrentDeliveryCommand;
 import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
 import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+import com.fhsh.daitda.deliverymanager.application.result.CompleteCurrentDeliveryResult;
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
 import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
@@ -18,12 +20,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -31,10 +36,10 @@ import static org.mockito.Mockito.verify;
 public class DeliveryManagerCommandServiceTest {
 
     @InjectMocks
-    private DeliveryManagerCommandService managerService;
+    private DeliveryManagerCommandService commandService;
 
     @Mock
-    private DeliveryManagerRepository managerRepository;
+    private DeliveryManagerRepository repository;
     @Mock
     private UserLookupService userLookupService;
 
@@ -56,17 +61,17 @@ public class DeliveryManagerCommandServiceTest {
             UserInfoCommand userInfo = new UserInfoCommand(targetUserId, hubId, "exampleId");
 
             given(userLookupService.getUser(targetUserId)).willReturn(userInfo);
-            given(managerRepository.existsByUserId(targetUserId)).willReturn(false);
-            given(managerRepository.findLastSequence(DeliveryManagerType.COMPANY, hubId)).willReturn(7); // 현재 마지막 순번 7번
-            given(managerRepository.save(any(DeliveryManager.class)))
+            given(repository.existsByUserId(targetUserId)).willReturn(false);
+            given(repository.findLastSequence(DeliveryManagerType.COMPANY, hubId)).willReturn(7); // 현재 마지막 순번 7번
+            given(repository.save(any(DeliveryManager.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            managerService.createDeliveryManager(command);
+            commandService.createDeliveryManager(command);
 
             // then
             ArgumentCaptor<DeliveryManager> captor = ArgumentCaptor.forClass(DeliveryManager.class);
-            verify(managerRepository).save(captor.capture());
+            verify(repository).save(captor.capture());
 
             // save 시점을 캡쳐한 결과 확인
             DeliveryManager saved = captor.getValue();
@@ -86,17 +91,17 @@ public class DeliveryManagerCommandServiceTest {
             UserInfoCommand userInfo = new UserInfoCommand(targetUserId, hubId, "exampleId");
 
             given(userLookupService.getUser(targetUserId)).willReturn(userInfo);
-            given(managerRepository.existsByUserId(targetUserId)).willReturn(false);
-            given(managerRepository.findLastSequence(DeliveryManagerType.COMPANY, hubId)).willReturn(10); // 현재 마지막 순번 10번
+            given(repository.existsByUserId(targetUserId)).willReturn(false);
+            given(repository.findLastSequence(DeliveryManagerType.COMPANY, hubId)).willReturn(10); // 현재 마지막 순번 10번
 
             // when & then
             // 10명 생성 초과 오류 발생
-            assertThatThrownBy(() -> managerService.createDeliveryManager(command))
+            assertThatThrownBy(() -> commandService.createDeliveryManager(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(DeliveryManagerErrorCode.DELIVERY_MANAGER_LIMIT_EXCEEDED);
 
-            verify(managerRepository, never()).save(any(DeliveryManager.class));
+            verify(repository, never()).save(any(DeliveryManager.class));
         }
 
         @Test
@@ -114,15 +119,15 @@ public class DeliveryManagerCommandServiceTest {
 
             given(userLookupService.getUser(targetUserId)).willReturn(userInfo);
             // 해당 userId의 배송담당자가 이미 존재하므로 true 반환
-            given(managerRepository.existsByUserId(targetUserId)).willReturn(true);
+            given(repository.existsByUserId(targetUserId)).willReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> managerService.createDeliveryManager(command))
+            assertThatThrownBy(() -> commandService.createDeliveryManager(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(DeliveryManagerErrorCode.DELIVERY_MANAGER_ALREADY_EXISTS);
 
-            verify(managerRepository, never()).save(any(DeliveryManager.class));
+            verify(repository, never()).save(any(DeliveryManager.class));
         }
 
         @Test
@@ -140,12 +145,79 @@ public class DeliveryManagerCommandServiceTest {
             given(userLookupService.getUser(targetUserId)).willReturn(userInfo);
 
             // when & then
-            assertThatThrownBy(() -> managerService.createDeliveryManager(command))
+            assertThatThrownBy(() -> commandService.createDeliveryManager(command))
                     .isInstanceOf(BusinessException.class)
                     .extracting("errorCode")
                     .isEqualTo(DeliveryManagerErrorCode.COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED);
 
-            verify(managerRepository, never()).save(any(DeliveryManager.class));
+            verify(repository, never()).save(any(DeliveryManager.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("배송담당자 배송 완료")
+    class CompleteCurrentDelivery {
+
+        @Test
+        @DisplayName("성공 케이스 - 배송 완료 성공")
+        void completeCurrentDelivery_success() {
+            // given
+            UUID deliveryManagerId = UUID.randomUUID();
+            UUID deliveryId = UUID.randomUUID();
+
+            DeliveryManager deliveryManager = new DeliveryManager(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    "exampleId",
+                    DeliveryManagerType.HUB,
+                    1,
+                    true
+            );
+
+            CompleteCurrentDeliveryCommand command = new CompleteCurrentDeliveryCommand(deliveryId, deliveryManagerId);
+
+            given(repository.findById(deliveryManagerId)).willReturn(Optional.of(deliveryManager));
+
+            // when
+            CompleteCurrentDeliveryResult result = commandService.completeCurrentDelivery(command);
+
+            // then
+            assertThat(result.deliveryId()).isEqualTo(deliveryId);
+            assertThat(result.isDelivery()).isFalse();
+            assertThat(deliveryManager.isDelivery()).isFalse();
+
+            then(repository).should().findById(deliveryManagerId);
+        }
+
+        @Test
+        @DisplayName("실패 케이스 - 배송중이 아닌 배송담당자가 요청하면 예외 발생")
+        void completeCurrentDelivery_fail_notDelivering() {
+            // given
+            UUID deliveryManagerId = UUID.randomUUID();
+            UUID deliveryId = UUID.randomUUID();
+
+            DeliveryManager deliveryManager = new DeliveryManager(
+                    UUID.randomUUID(),
+                    UUID.randomUUID(),
+                    "exampleId",
+                    DeliveryManagerType.HUB,
+                    1,
+                    false
+            );
+
+            CompleteCurrentDeliveryCommand command = new CompleteCurrentDeliveryCommand(deliveryId, deliveryManagerId);
+
+            given(repository.findById(deliveryManagerId)).willReturn(Optional.of(deliveryManager));
+
+            // when
+            Throwable thrown = catchThrowable(() -> commandService.completeCurrentDelivery(command));
+
+            // then
+            assertThat(thrown)
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_DELIVERING.getDescription());
+
+            then(repository).should().findById(deliveryManagerId);
         }
     }
 

--- a/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
@@ -1,13 +1,18 @@
 package com.fhsh.daitda.deliverymanager.application.service.command;
 
 import com.fhsh.daitda.deliverymanager.application.client.UserLookupService;
+import com.fhsh.daitda.deliverymanager.application.command.CompleteAssignmentCommand;
 import com.fhsh.daitda.deliverymanager.application.command.CompleteCurrentDeliveryCommand;
 import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
 import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+import com.fhsh.daitda.deliverymanager.application.result.CompleteAssignmentResult;
 import com.fhsh.daitda.deliverymanager.application.result.CompleteCurrentDeliveryResult;
+import com.fhsh.daitda.deliverymanager.domain.entity.AssignmentCursor;
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
 import com.fhsh.daitda.deliverymanager.domain.exception.DeliveryManagerErrorCode;
+import com.fhsh.daitda.deliverymanager.domain.repository.AssignmentCursorRepository;
+import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerAssignmentRepository;
 import com.fhsh.daitda.deliverymanager.domain.repository.DeliveryManagerRepository;
 import com.fhsh.daitda.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +30,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -38,10 +44,15 @@ public class DeliveryManagerCommandServiceTest {
     @InjectMocks
     private DeliveryManagerCommandService commandService;
 
+
+    @Mock
+    private UserLookupService userLookupService;
     @Mock
     private DeliveryManagerRepository repository;
     @Mock
-    private UserLookupService userLookupService;
+    private DeliveryManagerAssignmentRepository assignmentRepository;
+    @Mock
+    private AssignmentCursorRepository cursorRepository;
 
     @Nested
     @DisplayName("배송담당자 생성")
@@ -218,6 +229,88 @@ public class DeliveryManagerCommandServiceTest {
                     .hasMessage(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_DELIVERING.getDescription());
 
             then(repository).should().findById(deliveryManagerId);
+        }
+    }
+
+    @Nested
+    @DisplayName("배송담당자 배정")
+    class AssignmentDeliveryManager {
+        @Test
+        @DisplayName("성공 케이스 - 다음 담당자 배정, 커서 갱신")
+        void completeAssignment_success_withExistingCursor() {
+            // given
+            UUID deliveryId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            CompleteAssignmentCommand command = new CompleteAssignmentCommand(deliveryId, hubId);
+
+            AssignmentCursor cursor = AssignmentCursor.init(DeliveryManagerType.COMPANY, hubId);
+            cursor.advanceTo(3); // 다음 시작 순번은 4
+
+            // 배정 받을 4번 배송담당자 생성
+            DeliveryManager deliveryManager = DeliveryManager.create(
+                    UUID.randomUUID(),
+                    hubId,
+                    "exampleId",
+                    DeliveryManagerType.COMPANY,
+                    4
+            );
+
+            given(cursorRepository.findByTypeAndHubId(DeliveryManagerType.COMPANY, hubId))
+                    .willReturn(Optional.of(cursor));
+
+            given(assignmentRepository.findNextAssignable(DeliveryManagerType.COMPANY, hubId, 4))
+                    .willReturn(Optional.of(deliveryManager));
+
+            // when
+            CompleteAssignmentResult result = commandService.completeAssignment(command);
+
+            // then
+            assertThat(result.deliveryManagerId()).isEqualTo(deliveryManager.getDeliveryManagerId());
+            assertThat(cursor.getLastAssignedSequence()).isEqualTo(4);
+
+            then(cursorRepository).should().findByTypeAndHubId(DeliveryManagerType.COMPANY, hubId);
+            then(cursorRepository).should(never()).save(any(AssignmentCursor.class));
+            then(assignmentRepository).should().findNextAssignable(DeliveryManagerType.COMPANY, hubId, 4);
+        }
+
+        @Test
+        @DisplayName("성공 케이스 - 커서가 없으면 새 커서 생성, 첫 담당자 배정")
+        void completeAssignment_success_withNewCursor() {
+            // given
+            UUID deliveryId = UUID.randomUUID();
+
+            CompleteAssignmentCommand command = new CompleteAssignmentCommand(deliveryId, null);
+
+            AssignmentCursor newCursor = AssignmentCursor.init(DeliveryManagerType.HUB, null);
+
+            DeliveryManager deliveryManager = DeliveryManager.create(
+                    UUID.randomUUID(),
+                    null,
+                    "exampleId",
+                    DeliveryManagerType.HUB,
+                    1
+            );
+
+            given(cursorRepository.findByTypeAndHubId(DeliveryManagerType.HUB, null))
+                    .willReturn(Optional.empty());
+
+            given(cursorRepository.save(any(AssignmentCursor.class)))
+                    .willReturn(newCursor);
+
+            given(assignmentRepository.findNextAssignable(DeliveryManagerType.HUB, null, 1))
+                    .willReturn(Optional.of(deliveryManager));
+
+            // when
+            CompleteAssignmentResult result = commandService.completeAssignment(command);
+
+            // then
+            assertThat(result.deliveryManagerId()).isEqualTo(deliveryManager.getDeliveryManagerId());
+            assertThat(newCursor.getLastAssignedSequence()).isEqualTo(1);
+
+            then(cursorRepository).should().findByTypeAndHubId(DeliveryManagerType.HUB, null);
+            then(cursorRepository).should().save(any(AssignmentCursor.class)); // 새 커서 만들어서 저장
+            then(assignmentRepository).should().findNextAssignable(DeliveryManagerType.HUB, null, 1);
         }
     }
 

--- a/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManagerTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManagerTest.java
@@ -18,7 +18,7 @@ public class DeliveryManagerTest {
     void create() {
         UUID userId = UUID.randomUUID();
         UUID hubId = UUID.randomUUID();
-        String slackId = "slack-123";
+        String slackId = "exampleId";
 
         DeliveryManager manager = DeliveryManager.create(
                 userId, hubId, slackId, DeliveryManagerType.COMPANY, 3
@@ -41,7 +41,7 @@ public class DeliveryManagerTest {
                 DeliveryManager.create(
                         UUID.randomUUID(),
                         null,
-                        "slack-123",
+                        "exampleId",
                         DeliveryManagerType.COMPANY,
                         1
                 )
@@ -56,7 +56,7 @@ public class DeliveryManagerTest {
         DeliveryManager manager = DeliveryManager.create(
                 UUID.randomUUID(),
                 UUID.randomUUID(),
-                "slack-123",
+                "exampleId",
                 DeliveryManagerType.HUB,
                 1
         );
@@ -73,7 +73,7 @@ public class DeliveryManagerTest {
         DeliveryManager manager = DeliveryManager.create(
                 UUID.randomUUID(),
                 UUID.randomUUID(),
-                "slack-123",
+                "exampleId",
                 DeliveryManagerType.HUB,
                 1
         );


### PR DESCRIPTION
## 🌱 설명

- 배송담당자의 배송 완료 API 구현
- 배송담당자 배정 로직 구현

## 📌 관련 이슈

- close #11 

## ✅ 주요 변경 사항

- 배송 완료 메시지 발행을 제외한 배송 상태 완료 변경 API 구현
- 배송담당자 배정 로직 구현

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 배송 완료 API의 경우, 완료 시 배송 서비스로의 메시지 발행이 추가될 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 배송 완료 엔드포인트 추가 (PATCH /me/deliveries/{deliveryId}/complete)
  * 내부 배정 완료 엔드포인트 추가 (POST /internal/v1/delivery-managers/assignments)
  * 완료/할당용 요청·응답·결과 페이로드(DTO) 추가

* **개선 사항**
  * 목록 조회에 페이지 크기 파라미터 추가(기본 10)
  * 할당 탐색의 순번 검색 범위 명확화
  * 일부 식별자 타입 String→UUID로 정합성 개선
  * 배송담당자 조회용 repository 메서드 추가

* **버그 수정/오류 처리**
  * 배정 불가 시 명확한 오류 코드/메시지 추가
  * 권한 확인에서 HUB → HUB_ADMIN 반영

* **테스트**
  * 완료 및 할당 흐름 단위 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->