### PR TITLE
Feat: 카프카 의존성 추가 및 비동기 통신 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 	// spring security
 	//implementation 'org.springframework.boot:spring-boot-starter-security'
 }

--- a/src/main/java/com/fhsh/daitda/DaitdaApplication.java
+++ b/src/main/java/com/fhsh/daitda/DaitdaApplication.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableFeignClients
-@EnableJpaAuditing
+@EnableJpaAuditing(auditorAwareRef = "headerAuditorAware")
 public class DaitdaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/client/UserLookupService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/client/UserLookupService.java
@@ -33,7 +33,8 @@ public class UserLookupService {
         return new UserInfoCommand(
                 data.userId(),
                 data.hubId(),
-                data.slackUserId()
+                data.slackUserId(),
+                data.role()
         );
     }
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/command/StartDeliveryCommand.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/command/StartDeliveryCommand.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.deliverymanager.application.command;
+
+import java.util.UUID;
+
+public record StartDeliveryCommand(
+        UUID deliveryId,
+        UUID deliveryManagerId
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/command/UserInfoCommand.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/command/UserInfoCommand.java
@@ -5,5 +5,6 @@ import java.util.UUID;
 public record UserInfoCommand(
         UUID userId,
         UUID hubId,
-        String slackUserId
+        String slackUserId,
+        String role
 ) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/port/DeliveryCompleteEventPort.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/port/DeliveryCompleteEventPort.java
@@ -1,0 +1,7 @@
+package com.fhsh.daitda.deliverymanager.application.port;
+
+import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryCompleteEvent;
+
+public interface DeliveryCompleteEventPort {
+    void send(DeliveryCompleteEvent event);
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/port/event/DeliveryCompleteEvent.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/port/event/DeliveryCompleteEvent.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.deliverymanager.application.port.event;
+
+import java.util.UUID;
+
+public record DeliveryCompleteEvent(
+        UUID deliveryId,
+        UUID deliveryManagerId
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/port/event/DeliveryStartEvent.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/port/event/DeliveryStartEvent.java
@@ -1,0 +1,8 @@
+package com.fhsh.daitda.deliverymanager.application.port.event;
+
+import java.util.UUID;
+
+public record DeliveryStartEvent(
+        UUID deliveryId,
+        UUID deliveryManagerId
+) { }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -16,6 +16,8 @@ import com.fhsh.daitda.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.UUID;
 
@@ -83,8 +85,22 @@ public class DeliveryManagerCommandService {
         // 배송 완료로 변경
         deliveryManager.completeDelivery(command.deliveryId());
 
-        // 배송 완료 메시지 발행
-        deliveryCompleteEventPort.send(new DeliveryCompleteEvent(command.deliveryId(), deliveryManager.getDeliveryManagerId()));
+        // 배송 완료 메시지
+        DeliveryCompleteEvent event = new DeliveryCompleteEvent(command.deliveryId(), deliveryManager.getDeliveryManagerId());
+
+        // 트랜잭션 롤백 시 메시지가 발행되지 않도록 커밋 이후에 발행
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    // 메시지 발행
+                    deliveryCompleteEventPort.send(event);
+                }
+            });
+        } else {
+            // 트랜잭션이 없으면 즉시 발행
+            deliveryCompleteEventPort.send(event);
+        }
 
         return new CompleteCurrentDeliveryResult(command.deliveryId(), deliveryManager.isDelivery());
     }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -126,6 +126,10 @@ public class DeliveryManagerCommandService {
             throw new BusinessException(DeliveryManagerErrorCode.USER_NOT_FOUND);
         }
 
+        if (!"DELIVERY".equals(userInfo.role())) {
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_ROLE_REQUIRED);
+        }
+
         if (command.type() == DeliveryManagerType.COMPANY && userInfo.hubId() == null) {
             throw new BusinessException(DeliveryManagerErrorCode.COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED);
         }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandService.java
@@ -1,14 +1,10 @@
 package com.fhsh.daitda.deliverymanager.application.service.command;
 
 import com.fhsh.daitda.deliverymanager.application.client.UserLookupService;
-import com.fhsh.daitda.deliverymanager.application.command.CompleteAssignmentCommand;
-import com.fhsh.daitda.deliverymanager.application.command.CompleteCurrentDeliveryCommand;
-import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
-import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
-import com.fhsh.daitda.deliverymanager.application.result.CompleteAssignmentResult;
-import com.fhsh.daitda.deliverymanager.application.result.CompleteCurrentDeliveryResult;
-import com.fhsh.daitda.deliverymanager.application.result.CreateDeliveryManagerResult;
-import com.fhsh.daitda.deliverymanager.application.result.DeleteDeliveryManagerResult;
+import com.fhsh.daitda.deliverymanager.application.command.*;
+import com.fhsh.daitda.deliverymanager.application.port.DeliveryCompleteEventPort;
+import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryCompleteEvent;
+import com.fhsh.daitda.deliverymanager.application.result.*;
 import com.fhsh.daitda.deliverymanager.domain.entity.AssignmentCursor;
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;
@@ -32,6 +28,7 @@ public class DeliveryManagerCommandService {
     private final UserLookupService userLookupService;
     private final DeliveryManagerAssignmentRepository deliveryManagerAssignmentRepository;
     private final AssignmentCursorRepository assignmentCursorRepository;
+    private final DeliveryCompleteEventPort deliveryCompleteEventPort;
 
     // 배송담당자 생성
     public CreateDeliveryManagerResult createDeliveryManager(CreateDeliveryManagerCommand command) {
@@ -86,7 +83,8 @@ public class DeliveryManagerCommandService {
         // 배송 완료로 변경
         deliveryManager.completeDelivery(command.deliveryId());
 
-        // 배송 완료 메시지 발행 필요
+        // 배송 완료 메시지 발행
+        deliveryCompleteEventPort.send(new DeliveryCompleteEvent(command.deliveryId(), deliveryManager.getDeliveryManagerId()));
 
         return new CompleteCurrentDeliveryResult(command.deliveryId(), deliveryManager.isDelivery());
     }
@@ -113,6 +111,14 @@ public class DeliveryManagerCommandService {
         cursor.advanceTo(deliveryManager.getSequence());
 
         return CompleteAssignmentResult.from(deliveryManager, command.deliveryId());
+    }
+
+    // 배송 시작 처리
+    public void startDelivery(StartDeliveryCommand command) {
+        DeliveryManager deliveryManager = deliveryManagerRepository.findById(command.deliveryManagerId())
+                .orElseThrow(() -> new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_FOUND));
+
+        deliveryManager.startDelivery(command.deliveryId());
     }
 
     private void validateUser(UserInfoCommand userInfo, CreateDeliveryManagerCommand command) {

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
@@ -137,7 +137,7 @@ public class DeliveryManager extends BaseUserEntity {
         if (!this.isDelivery) {
             throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_DELIVERING);
         }
-        if (!Objects.equals(this.deliveryId, deliveryId)) {
+        if (this.deliveryId == null || !this.deliveryId.equals(deliveryId)) {
             throw new BusinessException(DeliveryManagerErrorCode.NOT_CURRENT_DELIVERY);
         }
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
-import java.util.Objects;
 import java.util.UUID;
 
 /*

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/entity/DeliveryManager.java
@@ -125,6 +125,9 @@ public class DeliveryManager extends BaseUserEntity {
         if (this.isDelivery) {
             throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_MANAGER_ALREADY_DELIVERING);
         }
+        if (deliveryId == null) {
+            throw new BusinessException(DeliveryManagerErrorCode.DELIVERY_ID_REQUIRED);
+        }
         this.deliveryId = deliveryId;
         this.isDelivery = true;
     }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
@@ -16,6 +16,7 @@ public enum DeliveryManagerErrorCode implements ErrorCode {
 
     USER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "userId는 필수입니다."),
     SLACK_ID_REQUIRED(HttpStatus.BAD_REQUEST, "slackId는 필수입니다."),
+    DELIVERY_ROLE_REQUIRED(HttpStatus.BAD_REQUEST, "배송 담당자 권한을 보유한 사용자만 배송 담당자로 생성될 수 있습니다."),
     DELIVERY_MANAGER_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "배송 담당자 타입은 필수입니다."),
     COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED(HttpStatus.BAD_REQUEST, "업체 배송 담당자는 허브 ID가 필요합니다."),
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/domain/exception/DeliveryManagerErrorCode.java
@@ -17,6 +17,7 @@ public enum DeliveryManagerErrorCode implements ErrorCode {
     USER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "userId는 필수입니다."),
     SLACK_ID_REQUIRED(HttpStatus.BAD_REQUEST, "slackId는 필수입니다."),
     DELIVERY_ROLE_REQUIRED(HttpStatus.BAD_REQUEST, "배송 담당자 권한을 보유한 사용자만 배송 담당자로 생성될 수 있습니다."),
+    DELIVERY_ID_REQUIRED(HttpStatus.BAD_REQUEST, "담당할 배송 아이디가 필요합니다."),
     DELIVERY_MANAGER_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "배송 담당자 타입은 필수입니다."),
     COMPANY_DELIVERY_MANAGER_HUB_ID_REQUIRED(HttpStatus.BAD_REQUEST, "업체 배송 담당자는 허브 ID가 필요합니다."),
 

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/config/KafkaTopicConfig.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/config/KafkaTopicConfig.java
@@ -1,4 +1,4 @@
-package com.fhsh.daitda.deliverymanager.infrastructure.messaging;
+package com.fhsh.daitda.deliverymanager.infrastructure.config;
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.context.annotation.Bean;
@@ -8,18 +8,21 @@ import org.springframework.kafka.config.TopicBuilder;
 @Configuration
 public class KafkaTopicConfig {
 
+    public static final String DELIVERY_START_REQUEST = "delivery.start.request";
+    public static final String DELIVERY_COMPLETE_REQUEST = "delivery.complete.request";
+
     @Bean
     public NewTopic deliveryStartRequestTopic() {
-        return TopicBuilder.name("delivery.start.request")
-                .partitions(3)
+        return TopicBuilder.name(DELIVERY_START_REQUEST)
+                .partitions(1) // 병렬 처리 계획이 없으므로 1로 설정
                 .replicas(1)
                 .build();
     }
 
     @Bean
     public NewTopic deliveryCompleteRequestTopic() {
-        return TopicBuilder.name("delivery.complete.request")
-                .partitions(3)
+        return TopicBuilder.name(DELIVERY_COMPLETE_REQUEST)
+                .partitions(1)
                 .replicas(1)
                 .build();
     }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/external/UserAdapter.java
@@ -24,6 +24,6 @@ public class UserAdapter implements UserClient {
             return null;
         }
 
-        return new UserInfoCommand(response.userId(), response.hubId(), response.slackUserId());
+        return new UserInfoCommand(response.userId(), response.hubId(), response.slackUserId(), response.role());
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/DeliveryCompleteMessage.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/DeliveryCompleteMessage.java
@@ -1,0 +1,17 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.messaging;
+
+import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryCompleteEvent;
+
+import java.util.UUID;
+
+public record DeliveryCompleteMessage(
+        UUID deliveryId,
+        UUID deliveryManagerId
+) {
+    public static DeliveryCompleteMessage from(DeliveryCompleteEvent event) {
+        return new DeliveryCompleteMessage(
+                event.deliveryId(),
+                event.deliveryManagerId()
+        );
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/KafkaTopicConfig.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/KafkaTopicConfig.java
@@ -1,0 +1,26 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.messaging;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    @Bean
+    public NewTopic deliveryStartRequestTopic() {
+        return TopicBuilder.name("delivery.start.request")
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic deliveryCompleteRequestTopic() {
+        return TopicBuilder.name("delivery.complete.request")
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/consumer/DeliveryStartRequestConsumer.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/consumer/DeliveryStartRequestConsumer.java
@@ -1,0 +1,23 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.messaging.consumer;
+
+import com.fhsh.daitda.deliverymanager.application.command.StartDeliveryCommand;
+import com.fhsh.daitda.deliverymanager.application.service.command.DeliveryManagerCommandService;
+import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryStartEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryStartRequestConsumer {
+
+    private final DeliveryManagerCommandService commandService;
+
+    @KafkaListener(
+            topics = "delivery.start.request",
+            groupId = "delivery-manager-service"
+    )
+    public void consume(DeliveryStartEvent event) {
+        commandService.startDelivery(new StartDeliveryCommand(event.deliveryId(), event.deliveryManagerId()));
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/consumer/DeliveryStartRequestConsumer.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/consumer/DeliveryStartRequestConsumer.java
@@ -3,6 +3,7 @@ package com.fhsh.daitda.deliverymanager.infrastructure.messaging.consumer;
 import com.fhsh.daitda.deliverymanager.application.command.StartDeliveryCommand;
 import com.fhsh.daitda.deliverymanager.application.service.command.DeliveryManagerCommandService;
 import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryStartEvent;
+import com.fhsh.daitda.deliverymanager.infrastructure.config.KafkaTopicConfig;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -14,7 +15,7 @@ public class DeliveryStartRequestConsumer {
     private final DeliveryManagerCommandService commandService;
 
     @KafkaListener(
-            topics = "delivery.start.request",
+            topics = KafkaTopicConfig.DELIVERY_START_REQUEST,
             groupId = "delivery-manager-service"
     )
     public void consume(DeliveryStartEvent event) {

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/producer/DeliveryCompleteRequestProducer.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/producer/DeliveryCompleteRequestProducer.java
@@ -5,11 +5,13 @@ import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryCompleteEv
 import com.fhsh.daitda.deliverymanager.infrastructure.config.KafkaTopicConfig;
 import com.fhsh.daitda.deliverymanager.infrastructure.messaging.DeliveryCompleteMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class DeliveryCompleteRequestProducer implements DeliveryCompleteEventPort {
 
     private final KafkaTemplate<String, DeliveryCompleteMessage> kafkaTemplate;
@@ -17,6 +19,12 @@ public class DeliveryCompleteRequestProducer implements DeliveryCompleteEventPor
     @Override
     public void send(DeliveryCompleteEvent event) {
         DeliveryCompleteMessage message = DeliveryCompleteMessage.from(event);
-        kafkaTemplate.send(KafkaTopicConfig.DELIVERY_COMPLETE_REQUEST, event.deliveryId().toString(), message);
+        kafkaTemplate
+                .send(KafkaTopicConfig.DELIVERY_COMPLETE_REQUEST, event.deliveryId().toString(), message)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka publish failed. topic={}, deliveryId={}", KafkaTopicConfig.DELIVERY_COMPLETE_REQUEST, event.deliveryId(), ex);
+                    }
+                });
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/producer/DeliveryCompleteRequestProducer.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/producer/DeliveryCompleteRequestProducer.java
@@ -2,6 +2,7 @@ package com.fhsh.daitda.deliverymanager.infrastructure.messaging.producer;
 
 import com.fhsh.daitda.deliverymanager.application.port.DeliveryCompleteEventPort;
 import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryCompleteEvent;
+import com.fhsh.daitda.deliverymanager.infrastructure.config.KafkaTopicConfig;
 import com.fhsh.daitda.deliverymanager.infrastructure.messaging.DeliveryCompleteMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -16,6 +17,6 @@ public class DeliveryCompleteRequestProducer implements DeliveryCompleteEventPor
     @Override
     public void send(DeliveryCompleteEvent event) {
         DeliveryCompleteMessage message = DeliveryCompleteMessage.from(event);
-        kafkaTemplate.send("delivery.complete.request", event.deliveryId().toString(), message);
+        kafkaTemplate.send(KafkaTopicConfig.DELIVERY_COMPLETE_REQUEST, event.deliveryId().toString(), message);
     }
 }

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/producer/DeliveryCompleteRequestProducer.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/producer/DeliveryCompleteRequestProducer.java
@@ -1,0 +1,21 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.messaging.producer;
+
+import com.fhsh.daitda.deliverymanager.application.port.DeliveryCompleteEventPort;
+import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryCompleteEvent;
+import com.fhsh.daitda.deliverymanager.infrastructure.messaging.DeliveryCompleteMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryCompleteRequestProducer implements DeliveryCompleteEventPort {
+
+    private final KafkaTemplate<String, DeliveryCompleteMessage> kafkaTemplate;
+
+    @Override
+    public void send(DeliveryCompleteEvent event) {
+        DeliveryCompleteMessage message = DeliveryCompleteMessage.from(event);
+        kafkaTemplate.send("delivery.complete.request", event.deliveryId().toString(), message);
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/auditing/HeaderAuditorAware.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/auditing/HeaderAuditorAware.java
@@ -1,0 +1,46 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.persistence.auditing;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class HeaderAuditorAware implements AuditorAware<UUID> {
+
+    // Gateway에서 내려주는 사용자 ID 헤더 이름
+    private static final String HEADER_USER_ID = "X-User-Id";
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+        // 현재 요청 스레드에 바인딩된 RequestAttributes를 가져옴
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        // HTTP 요청이 없는 상황이면 현재 사용자 정보를 알 수 없으므로 빈 값 반환
+        if (attributes == null) {
+            return Optional.empty();
+        }
+
+        // 실제 HttpServletRequest 객체 꺼냄
+        HttpServletRequest request = attributes.getRequest();
+        // 요청 헤더에서 X-User-Id 값 읽어옴
+        String userId = request.getHeader(HEADER_USER_ID);
+
+        // 헤더가 없거나 값이 비어 있으면 감사자 정보를 알 수 없으므로 빈 값 반환
+        if (userId == null || userId.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            // 문자열 형태의 userId를 UUID로 변환해서 반환하고, @CreatedBy, @LastModifiedBy 필드에 자동 반영됨
+            return Optional.of(UUID.fromString(userId));
+        } catch (IllegalArgumentException e) {
+            // 헤더 값이 UUID 형식이 아니면 예외를 터뜨리지 않고 빈 값 반환
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/AssignmentCursorJpaRepository.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/AssignmentCursorJpaRepository.java
@@ -1,4 +1,4 @@
-package com.fhsh.daitda.deliverymanager.infrastructure.repository;
+package com.fhsh.daitda.deliverymanager.infrastructure.persistence.repository;
 
 import com.fhsh.daitda.deliverymanager.domain.entity.AssignmentCursor;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/AssignmentCursorRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/AssignmentCursorRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.fhsh.daitda.deliverymanager.infrastructure.repository;
+package com.fhsh.daitda.deliverymanager.infrastructure.persistence.repository;
 
 import com.fhsh.daitda.deliverymanager.domain.entity.AssignmentCursor;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/DeliveryManagerAssignmentRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/DeliveryManagerAssignmentRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.fhsh.daitda.deliverymanager.infrastructure.repository;
+package com.fhsh.daitda.deliverymanager.infrastructure.persistence.repository;
 
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
 import com.fhsh.daitda.deliverymanager.domain.entity.QDeliveryManager;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/DeliveryManagerJpaRepository.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/DeliveryManagerJpaRepository.java
@@ -1,4 +1,4 @@
-package com.fhsh.daitda.deliverymanager.infrastructure.repository;
+package com.fhsh.daitda.deliverymanager.infrastructure.persistence.repository;
 
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/DeliveryManagerQueryRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/DeliveryManagerQueryRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.fhsh.daitda.deliverymanager.infrastructure.repository;
+package com.fhsh.daitda.deliverymanager.infrastructure.persistence.repository;
 
 import com.fhsh.daitda.deliverymanager.application.query.GetDeliveryManagerListQuery;
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;

--- a/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/DeliveryManagerRepositoryImpl.java
+++ b/src/main/java/com/fhsh/daitda/deliverymanager/infrastructure/persistence/repository/DeliveryManagerRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.fhsh.daitda.deliverymanager.infrastructure.repository;
+package com.fhsh.daitda.deliverymanager.infrastructure.persistence.repository;
 
 import com.fhsh.daitda.deliverymanager.domain.entity.DeliveryManager;
 import com.fhsh.daitda.deliverymanager.domain.enums.DeliveryManagerType;

--- a/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
@@ -201,6 +201,7 @@ public class DeliveryManagerCommandServiceTest {
             assertThat(deliveryManager.isDelivery()).isFalse();
 
             then(repository).should().findByUserId(userId);
+            then(deliveryCompleteEventPort).should().send(any());
         }
 
         @Test
@@ -233,6 +234,7 @@ public class DeliveryManagerCommandServiceTest {
                     .hasMessage(DeliveryManagerErrorCode.DELIVERY_MANAGER_NOT_DELIVERING.getDescription());
 
             then(repository).should().findByUserId(userId);
+            then(deliveryCompleteEventPort).should(never()).send(any());
         }
     }
 

--- a/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/application/service/command/DeliveryManagerCommandServiceTest.java
@@ -5,6 +5,7 @@ import com.fhsh.daitda.deliverymanager.application.command.CompleteAssignmentCom
 import com.fhsh.daitda.deliverymanager.application.command.CompleteCurrentDeliveryCommand;
 import com.fhsh.daitda.deliverymanager.application.command.CreateDeliveryManagerCommand;
 import com.fhsh.daitda.deliverymanager.application.command.UserInfoCommand;
+import com.fhsh.daitda.deliverymanager.application.port.DeliveryCompleteEventPort;
 import com.fhsh.daitda.deliverymanager.application.result.CompleteAssignmentResult;
 import com.fhsh.daitda.deliverymanager.application.result.CompleteCurrentDeliveryResult;
 import com.fhsh.daitda.deliverymanager.domain.entity.AssignmentCursor;
@@ -52,6 +53,8 @@ public class DeliveryManagerCommandServiceTest {
     private DeliveryManagerAssignmentRepository assignmentRepository;
     @Mock
     private AssignmentCursorRepository cursorRepository;
+    @Mock
+    private DeliveryCompleteEventPort deliveryCompleteEventPort;
 
     @Nested
     @DisplayName("배송담당자 생성")
@@ -68,7 +71,7 @@ public class DeliveryManagerCommandServiceTest {
             CreateDeliveryManagerCommand command = new CreateDeliveryManagerCommand(targetUserId, DeliveryManagerType.COMPANY);
 
             // 예시 사용자 정보
-            UserInfoCommand userInfo = new UserInfoCommand(targetUserId, hubId, "exampleId");
+            UserInfoCommand userInfo = new UserInfoCommand(targetUserId, hubId, "exampleId", "DELIVERY");
 
             given(userLookupService.getUser(targetUserId)).willReturn(userInfo);
             given(repository.existsByUserId(targetUserId)).willReturn(false);
@@ -98,7 +101,7 @@ public class DeliveryManagerCommandServiceTest {
 
             CreateDeliveryManagerCommand command = new CreateDeliveryManagerCommand(targetUserId, DeliveryManagerType.COMPANY);
 
-            UserInfoCommand userInfo = new UserInfoCommand(targetUserId, hubId, "exampleId");
+            UserInfoCommand userInfo = new UserInfoCommand(targetUserId, hubId, "exampleId", "DELIVERY");
 
             given(userLookupService.getUser(targetUserId)).willReturn(userInfo);
             given(repository.existsByUserId(targetUserId)).willReturn(false);
@@ -125,7 +128,7 @@ public class DeliveryManagerCommandServiceTest {
                     new CreateDeliveryManagerCommand(targetUserId, DeliveryManagerType.COMPANY);
 
             UserInfoCommand userInfo =
-                    new UserInfoCommand(targetUserId, hubId, "exampleId");
+                    new UserInfoCommand(targetUserId, hubId, "exampleId", "DELIVERY");
 
             given(userLookupService.getUser(targetUserId)).willReturn(userInfo);
             // 해당 userId의 배송담당자가 이미 존재하므로 true 반환
@@ -150,7 +153,7 @@ public class DeliveryManagerCommandServiceTest {
                     new CreateDeliveryManagerCommand(targetUserId, DeliveryManagerType.COMPANY);
 
             UserInfoCommand userInfo =
-                    new UserInfoCommand(targetUserId, null, "exampleId");
+                    new UserInfoCommand(targetUserId, null, "exampleId", "DELIVERY");
 
             given(userLookupService.getUser(targetUserId)).willReturn(userInfo);
 

--- a/src/test/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/consumer/DeliveryStartRequestConsumerTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/consumer/DeliveryStartRequestConsumerTest.java
@@ -1,0 +1,50 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.messaging.consumer;
+
+import com.fhsh.daitda.deliverymanager.application.command.StartDeliveryCommand;
+import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryStartEvent;
+import com.fhsh.daitda.deliverymanager.application.service.command.DeliveryManagerCommandService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryStartRequestConsumerTest {
+
+    @Mock
+    private DeliveryManagerCommandService commandService;
+
+    @InjectMocks
+    private DeliveryStartRequestConsumer consumer;
+
+    @Test
+    @DisplayName("성공 케이스 - 배송 시작 이벤트를 받으면 startDelivery 호출")
+    void consume_success() {
+        // given
+        UUID deliveryId = UUID.randomUUID();
+        UUID deliveryManagerId = UUID.randomUUID();
+
+        DeliveryStartEvent event = new DeliveryStartEvent(deliveryId, deliveryManagerId);
+
+        // when
+        consumer.consume(event);
+
+        // then
+        ArgumentCaptor<StartDeliveryCommand> captor =
+                ArgumentCaptor.forClass(StartDeliveryCommand.class);
+
+        verify(commandService).startDelivery(captor.capture());
+
+        StartDeliveryCommand command = captor.getValue();
+        assertThat(command.deliveryId()).isEqualTo(deliveryId);
+        assertThat(command.deliveryManagerId()).isEqualTo(deliveryManagerId);
+    }
+}

--- a/src/test/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/producer/DeliveryCompleteRequestProducerTest.java
+++ b/src/test/java/com/fhsh/daitda/deliverymanager/infrastructure/messaging/producer/DeliveryCompleteRequestProducerTest.java
@@ -1,0 +1,56 @@
+package com.fhsh.daitda.deliverymanager.infrastructure.messaging.producer;
+
+import com.fhsh.daitda.deliverymanager.application.port.event.DeliveryCompleteEvent;
+import com.fhsh.daitda.deliverymanager.infrastructure.config.KafkaTopicConfig;
+import com.fhsh.daitda.deliverymanager.infrastructure.messaging.DeliveryCompleteMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DeliveryCompleteRequestProducerTest {
+
+    @Mock
+    private KafkaTemplate<String, DeliveryCompleteMessage> kafkaTemplate;
+
+    @InjectMocks
+    private DeliveryCompleteRequestProducer producer;
+
+    @Test
+    @DisplayName("성공 케이스 - 배송 완료 이벤트를 올바른 토픽과 key, message로 발행")
+    void send_success() {
+        // given
+        UUID deliveryId = UUID.randomUUID();
+        UUID deliveryManagerId = UUID.randomUUID();
+
+        DeliveryCompleteEvent event = new DeliveryCompleteEvent(deliveryId, deliveryManagerId);
+
+        // when
+        producer.send(event);
+
+        // then
+        ArgumentCaptor<DeliveryCompleteMessage> captor =
+                ArgumentCaptor.forClass(DeliveryCompleteMessage.class);
+
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConfig.DELIVERY_COMPLETE_REQUEST),
+                eq(deliveryId.toString()),
+                captor.capture()
+        );
+
+        DeliveryCompleteMessage message = captor.getValue();
+        assertThat(message.deliveryId()).isEqualTo(deliveryId);
+        assertThat(message.deliveryManagerId()).isEqualTo(deliveryManagerId);
+    }
+}


### PR DESCRIPTION
## 🌱 설명

비동기 통신 구현 (kafka 적용)

## 📌 관련 이슈

- close #15 

## ✅ 주요 변경 사항

- 카프카 의존성 추가
- Producer 구현, 기존 로직에서 메시지 발행 로직 추가
- Consumer 구현, 메시지 처리 로직 구현
- 메시지 발행/소비 로직 테스트 코드 추가
- 감사 필드 중 createdBy, updatedBy 필드가 자동으로 관리되도록 설정 추가

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

현재는 kafka 서버 연결 없이 단위 테스트로만 확인하였습니다! config server에서 관련 설정 추가 시 docker로 띄워 테스트 할 예정입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 역할 기반 배송 담당자 검증 추가(DELIVERY 역할 필수)
  * 배송 시작/완료 이벤트 발행 및 처리 기능 추가
  * Kafka 토픽 등록 및 메시지 생산/소비 연동 추가

* **리팩토링**
  * 패키지 구조 정리 및 JPA 감사 구성 변경(헤더 기반 감사자 지원)
  * 배포 흐름에서 완료 이벤트를 트랜잭션 커밋 후 발행하도록 보장

* **테스트**
  * 메시징 소비자/생산자 및 관련 서비스 단위 테스트 추가

* **잡업(Chore)**
  * 빌드에 Kafka 관련 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->